### PR TITLE
Use the cryptography package rather than PyOpenSSL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,6 @@ install_requires = [
     # load_pem_private/public_key (>=0.6)
     # rsa_recover_prime_factors (>=0.8)
     'cryptography>=0.8',
-    # Connection.set_tlsext_host_name (>=0.13)
-    'PyOpenSSL>=0.13',
     # For pkg_resources. >=1.0 so pip resolves it to a version cryptography
     # will tolerate; see #2599:
     'setuptools>=1.0',
@@ -20,6 +18,7 @@ install_requires = [
 
 testing_requires = [
     'coverage>=4.0',
+    'PyOpenSSL>=0.13',
     'pytest-isort',
     'pytest-cache>=1.0',
     'pytest-cov',

--- a/src/josepy/json_util.py
+++ b/src/josepy/json_util.py
@@ -10,8 +10,11 @@ import abc
 import binascii
 import logging
 
-import OpenSSL
 import six
+
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
 
 from josepy import b64, errors, interfaces, util
 
@@ -360,50 +363,49 @@ def decode_hex16(value, size=None, minimum=False):
 def encode_cert(cert):
     """Encode certificate as JOSE Base-64 DER.
 
-    :type cert: `OpenSSL.crypto.X509` wrapped in `.ComparableX509`
+    :type `ComparableX509` cert:
     :rtype: unicode
 
     """
-    return encode_b64jose(OpenSSL.crypto.dump_certificate(
-        OpenSSL.crypto.FILETYPE_ASN1, cert.wrapped))
+    return encode_b64jose(cert.public_bytes(serialization.Encoding.DER))
 
 
 def decode_cert(b64der):
     """Decode JOSE Base-64 DER-encoded certificate.
 
     :param unicode b64der:
-    :rtype: `OpenSSL.crypto.X509` wrapped in `.ComparableX509`
+    :rtype: `ComparableX509`
 
     """
     try:
-        return util.ComparableX509(OpenSSL.crypto.load_certificate(
-            OpenSSL.crypto.FILETYPE_ASN1, decode_b64jose(b64der)))
-    except OpenSSL.crypto.Error as error:
+        cert = x509.load_der_x509_certificate(
+            decode_b64jose(b64der), default_backend())
+        return util.ComparableX509(cert)
+    except ValueError as error:
         raise errors.DeserializationError(error)
 
 
 def encode_csr(csr):
     """Encode CSR as JOSE Base-64 DER.
 
-    :type csr: `OpenSSL.crypto.X509Req` wrapped in `.ComparableX509`
+    :type `ComparableX509` csr:
     :rtype: unicode
 
     """
-    return encode_b64jose(OpenSSL.crypto.dump_certificate_request(
-        OpenSSL.crypto.FILETYPE_ASN1, csr.wrapped))
+    return encode_b64jose(csr.public_bytes(serialization.Encoding.DER))
 
 
 def decode_csr(b64der):
     """Decode JOSE Base-64 DER-encoded CSR.
 
     :param unicode b64der:
-    :rtype: `OpenSSL.crypto.X509Req` wrapped in `.ComparableX509`
+    :rtype: `ComparableX509`
 
     """
     try:
-        return util.ComparableX509(OpenSSL.crypto.load_certificate_request(
-            OpenSSL.crypto.FILETYPE_ASN1, decode_b64jose(b64der)))
-    except OpenSSL.crypto.Error as error:
+        cert = x509.load_der_x509_csr(decode_b64jose(b64der), default_backend())
+        return util.ComparableX509(cert)
+    except ValueError as error:
         raise errors.DeserializationError(error)
 
 

--- a/src/josepy/json_util.py
+++ b/src/josepy/json_util.py
@@ -11,7 +11,6 @@ import binascii
 import logging
 
 import six
-
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization

--- a/src/josepy/jws.py
+++ b/src/josepy/jws.py
@@ -4,7 +4,6 @@ import base64
 import sys
 
 import six
-
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization

--- a/src/josepy/util.py
+++ b/src/josepy/util.py
@@ -2,7 +2,6 @@
 import collections
 
 import six
-
 from cryptography import x509
 from cryptography.hazmat.primitives.asymmetric import rsa
 

--- a/src/josepy/util.py
+++ b/src/josepy/util.py
@@ -1,8 +1,9 @@
 """JOSE utilities."""
 import collections
 
-import OpenSSL
 import six
+
+from cryptography import x509
 from cryptography.hazmat.primitives.asymmetric import rsa
 
 
@@ -30,43 +31,35 @@ class ComparableX509(object):  # pylint: disable=too-few-public-methods
     """Wrapper for OpenSSL.crypto.X509** objects that supports __eq__.
 
     :ivar wrapped: Wrapped certificate or certificate request.
-    :type wrapped: `OpenSSL.crypto.X509` or `OpenSSL.crypto.X509Req`.
-
+    :type wrapped: `cryptography` X509 object or `OpenSSL.crypto.X509` or
+                   `OpenSSL.crypto.X509Req`
     """
     def __init__(self, wrapped):
-        assert isinstance(wrapped, OpenSSL.crypto.X509) or isinstance(
-            wrapped, OpenSSL.crypto.X509Req)
-        self.wrapped = wrapped
+        if isinstance(wrapped, x509.Certificate) or \
+           isinstance(wrapped, x509.CertificateSigningRequest):
+            self.wrapped = wrapped
+        else:
+            # Fallback: Try OpenSSL?
+            self.wrapped = self._from_openssl(wrapped)
+
+    def _from_openssl(self, it):
+        # This is a fallback method that attempts to convert from an OpenSSL
+        # object.
+        try:
+            return it.to_cryptography()
+        except AttributeError:
+            raise ValueError('Unexpected object type %s' % type(it))
 
     def __getattr__(self, name):
         return getattr(self.wrapped, name)
 
-    def _dump(self, filetype=OpenSSL.crypto.FILETYPE_ASN1):
-        """Dumps the object into a buffer with the specified encoding.
-
-        :param int filetype: The desired encoding. Should be one of
-            `OpenSSL.crypto.FILETYPE_ASN1`,
-            `OpenSSL.crypto.FILETYPE_PEM`, or
-            `OpenSSL.crypto.FILETYPE_TEXT`.
-
-        :returns: Encoded X509 object.
-        :rtype: str
-
-        """
-        if isinstance(self.wrapped, OpenSSL.crypto.X509):
-            func = OpenSSL.crypto.dump_certificate
-        else:  # assert in __init__ makes sure this is X509Req
-            func = OpenSSL.crypto.dump_certificate_request
-        return func(filetype, self.wrapped)
-
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return NotImplemented
-        # pylint: disable=protected-access
-        return self._dump() == other._dump()
+            return False
+        return self.wrapped == other.wrapped
 
     def __hash__(self):
-        return hash((self.__class__, self._dump()))
+        return hash((self.__class__, self.wrapped))
 
     def __ne__(self, other):
         return not self == other

--- a/src/josepy/util_test.py
+++ b/src/josepy/util_test.py
@@ -21,7 +21,7 @@ class ComparableX509Test(unittest.TestCase):
         self.cert_other = test_util.load_comparable_cert('cert-san.pem')
 
     def test_getattr_proxy(self):
-        self.assertTrue(self.cert1.has_expired())
+        self.assertIsNotNone(self.cert1.not_valid_after)
 
     def test_eq(self):
         self.assertEqual(self.req1, self.req2)


### PR DESCRIPTION
Sorry, at the moment I cannot run the tests, but this should be a good starting point if anyone wants to clean it up.

- Removes PyOpenSSL as a runtime requirement. It is still a testing requirement.
- Changes serialization and deserialization methods to use `cryptography.x509` objects instead of the corresponding objects in `OpenSSL.crypto`.
- Extends the `ComparableX509` class to wrap `cryptography.x509` objects and to convert `OpenSSL.crypto` objects for compatibility.

Addresses #1.