### PR TITLE
Use README.rst as long_description for PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,10 @@ docs_extras = [
 ]
 
 
+with open('README.rst') as f:
+    long_description = f.read()
+
+
 class PyTest(TestCommand):
     user_options = []
 
@@ -59,6 +63,7 @@ setup(
     name='josepy',
     version=version,
     description='JOSE protocol implementation in Python',
+    long_description=long_description,
     url='https://github.com/certbot/josepy',
     author="Certbot Project",
     author_email='client-dev@letsencrypt.org',

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import io
 import sys
 
 from setuptools import find_packages, setup
@@ -40,7 +41,7 @@ docs_extras = [
 ]
 
 
-with open('README.rst') as f:
+with io.open('README.rst', encoding='UTF-8') as f:
     long_description = f.read()
 
 


### PR DESCRIPTION
Currently https://pypi.org/project/josepy/ says

  Project Description

  UNKNOWN

which is a bit unfriendly.  Let's fix that.