### PR TITLE
Keep but deprecate ancient python support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: python
 sudo: false
 cache: pip
 python:
+  - "2.6"
   - "2.7"
+  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,13 @@ testing_requires = [
     'mock',
 ]
 
+# env markers cause problems with older pip and setuptools
+if sys.version_info < (2, 7):
+    install_requires.extend([
+        'argparse',
+        'ordereddict',
+    ])
+
 dev_extras = [
     'pytest',
     'tox',
@@ -75,8 +82,10 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,6 @@ setup(
     author="Certbot Project",
     author_email='client-dev@letsencrypt.org',
     license='Apache License 2.0',
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',

--- a/src/josepy/__init__.py
+++ b/src/josepy/__init__.py
@@ -25,6 +25,9 @@ Originally developed as part of the ACME_ protocol implementation.
 .. _ACME: https://pypi.python.org/pypi/acme
 
 """
+import sys
+import warnings
+
 # flake8: noqa
 from josepy.b64 import (
     b64decode,
@@ -84,3 +87,11 @@ from josepy.util import (
     ComparableRSAKey,
     ImmutableMap,
 )
+
+for (major, minor) in [(2, 6), (3, 3)]:
+    if sys.version_info[:2] == (major, minor):
+        warnings.warn(
+                "Python {0}.{1} support will be dropped in the next release of "
+                "josepy. Please upgrade your Python version.".format(major, minor),
+                DeprecationWarning,
+        )

--- a/src/josepy/test_util.py
+++ b/src/josepy/test_util.py
@@ -4,6 +4,7 @@
 
 """
 import os
+import unittest
 
 import OpenSSL
 import pkg_resources
@@ -73,3 +74,24 @@ def load_pyopenssl_private_key(*names):
     loader = _guess_loader(
         names[-1], OpenSSL.crypto.FILETYPE_PEM, OpenSSL.crypto.FILETYPE_ASN1)
     return OpenSSL.crypto.load_privatekey(loader, load_vector(*names))
+
+
+def skip_unless(condition, reason):  # pragma: no cover
+    """Skip tests unless a condition holds.
+
+    This implements the basic functionality of unittest.skipUnless
+    which is only available on Python 2.7+.
+
+    :param bool condition: If ``False``, the test will be skipped
+    :param str reason: the reason for skipping the test
+
+    :rtype: callable
+    :returns: decorator that hides tests unless condition is ``True``
+
+    """
+    if hasattr(unittest, "skipUnless"):
+        return unittest.skipUnless(condition, reason)
+    elif condition:
+        return lambda cls: cls
+    else:
+        return lambda cls: None

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py27
-    py3{4,5,6}
+    py2{6,7}
+    py3{3,4,5,6}
 
 [testenv]
 commands =


### PR DESCRIPTION
There aren't many but there are ~40 users who have downloaded `josepy` using Python 2.6 or 3.3 from PyPI in the last month. Let's not suddenly break things for them if they try and upgrade. This PR adds back Python 2.6 and 3.3 support (with tests) and adds a deprecation warning. This entire PR can be reverted later to drop 2.6 and 3.3 support.