### PR TITLE
Update changelog for 1.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+1.1.0 (2018-04-13)
+------------------
+
+* Deprecated support for Python 2.6 and 3.3.
+* Use the ``sign`` and ``verify`` methods when they are available in
+  ``cryptography`` instead of the deprecated methods ``signer`` and
+  ``verifier``.
+
 1.0.1 (2017-10-25)
 ------------------
 


### PR DESCRIPTION
Unlike Certbot, the changelog here is actually included in the package so let's get it updated before the release.