### PR TITLE
Add magic_typing and magic_typing_tests, update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+venv/
 build/
 develop-eggs/
 dist/
@@ -41,6 +42,7 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+.pytest_cache
 nosetests.xml
 coverage.xml
 *,cover

--- a/src/josepy/magic_typing.py
+++ b/src/josepy/magic_typing.py
@@ -1,0 +1,15 @@
+"""Shim class to not have to depend on typing module in prod."""
+import sys
+
+
+class TypingClass(object):
+    """Ignore import errors by getting anything"""
+    def __getattr__(self, name):
+        return None
+
+
+try:
+    # mypy doesn't respect modifying sys.modules
+    from typing import *  # noqa: F401,F403
+except ImportError:
+    sys.modules[__name__] = TypingClass()

--- a/src/josepy/magic_typing_test.py
+++ b/src/josepy/magic_typing_test.py
@@ -1,0 +1,41 @@
+"""Tests for josepy.magic_typing."""
+import sys
+import unittest
+
+import mock
+
+
+class MagicTypingTest(unittest.TestCase):
+    """Tests for josepy.magic_typing."""
+    def test_import_success(self):
+        try:
+            import typing as temp_typing
+        except ImportError:  # pragma: no cover
+            temp_typing = None  # pragma: no cover
+        typing_class_mock = mock.MagicMock()
+        text_mock = mock.MagicMock()
+        typing_class_mock.Text = text_mock
+        sys.modules['typing'] = typing_class_mock
+        if 'josepy.magic_typing' in sys.modules:
+            del sys.modules['josepy.magic_typing']  # pragma: no cover
+        from josepy.magic_typing import Text  # pylint: disable=no-name-in-module
+        self.assertEqual(Text, text_mock)
+        del sys.modules['josepy.magic_typing']
+        sys.modules['typing'] = temp_typing
+
+    def test_import_failure(self):
+        try:
+            import typing as temp_typing
+        except ImportError:  # pragma: no cover
+            temp_typing = None  # pragma: no cover
+        sys.modules['typing'] = None
+        if 'josepy.magic_typing' in sys.modules:
+            del sys.modules['josepy.magic_typing']  # pragma: no cover
+        from josepy.magic_typing import Text  # pylint: disable=no-name-in-module
+        self.assertTrue(Text is None)
+        del sys.modules['josepy.magic_typing']
+        sys.modules['typing'] = temp_typing
+
+
+if __name__ == '__main__':
+    unittest.main()  # pragma: no cover


### PR DESCRIPTION
Updates gitignore to include venv/ and .pytest_cache (for pytest update change in default naming)

Add magic_typing and magic_typing_tests as copies from certbot/acme updated for use with josepy