### PR TITLE
Add test_suite to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -106,6 +106,7 @@ setup(
         ],
     },
     tests_require=testing_requires,
+    test_suite='josepy',
     cmdclass={
         'test': PyTest,
     },


### PR DESCRIPTION
Versions of setuptools [prior to 18.4][18.4] would not invoke tests unless a value for `test_suite` was provided. To simplify packaging on distros that have old versions of setuptools (e.g. CentOS 7, Debian 8, Ubuntu 14.04), we specify a value for it.

[18.4]: https://setuptools.readthedocs.io/en/latest/history.html#id314