### PR TITLE
Make code compatible with Python >= 3.8 towards collections module

### DIFF
--- a/src/josepy/interfaces.py
+++ b/src/josepy/interfaces.py
@@ -1,14 +1,15 @@
 """JOSE interfaces."""
 import abc
 import json
-try:
-    from collections.abc import Sequence, Mapping  # pylint: disable=import-error
-except ImportError:
-    from collections import Sequence, Mapping
 
 import six
 
 from josepy import errors, util
+
+try:
+    from collections.abc import Sequence, Mapping  # pylint: disable=import-error
+except ImportError:
+    from collections import Sequence, Mapping
 
 # pylint: disable=no-self-argument,no-method-argument,no-init,inherit-non-class
 # pylint: disable=too-few-public-methods

--- a/src/josepy/interfaces.py
+++ b/src/josepy/interfaces.py
@@ -1,7 +1,10 @@
 """JOSE interfaces."""
 import abc
-import collections
 import json
+try:
+    from collections.abc import Sequence, Mapping  # pylint: disable=import-error
+except ImportError:
+    from collections import Sequence, Mapping
 
 import six
 
@@ -139,11 +142,11 @@ class JSONDeSerializable(object):
                 return obj
             elif isinstance(obj, list):
                 return [_serialize(subobj) for subobj in obj]
-            elif isinstance(obj, collections.Sequence):
+            elif isinstance(obj, Sequence):
                 # default to tuple, otherwise Mapping could get
                 # unhashable list
                 return tuple(_serialize(subobj) for subobj in obj)
-            elif isinstance(obj, collections.Mapping):
+            elif isinstance(obj, Mapping):
                 return dict((_serialize(key), _serialize(value))
                             for key, value in six.iteritems(obj))
             else:

--- a/src/josepy/jwa.py
+++ b/src/josepy/jwa.py
@@ -4,8 +4,11 @@ https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40
 
 """
 import abc
-import collections
 import logging
+try:
+    from collections.abc import Hashable  # pylint: disable=import-error
+except ImportError:
+    from collections import Hashable
 
 import cryptography.exceptions
 from cryptography.hazmat.backends import default_backend
@@ -25,7 +28,7 @@ class JWA(interfaces.JSONDeSerializable):  # pylint: disable=abstract-method
     """JSON Web Algorithm."""
 
 
-class JWASignature(JWA, collections.Hashable):  # type: ignore
+class JWASignature(JWA, Hashable):  # type: ignore
     """Base class for JSON Web Signature Algorithms."""
     SIGNATURES = {}  # type: dict
 

--- a/src/josepy/jwa.py
+++ b/src/josepy/jwa.py
@@ -5,10 +5,6 @@ https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40
 """
 import abc
 import logging
-try:
-    from collections.abc import Hashable  # pylint: disable=import-error
-except ImportError:
-    from collections import Hashable
 
 import cryptography.exceptions
 from cryptography.hazmat.backends import default_backend
@@ -17,6 +13,11 @@ from cryptography.hazmat.primitives import hmac  # type: ignore
 from cryptography.hazmat.primitives.asymmetric import padding  # type: ignore
 
 from josepy import errors, interfaces, jwk
+
+try:
+    from collections.abc import Hashable  # pylint: disable=import-error
+except ImportError:
+    from collections import Hashable
 
 logger = logging.getLogger(__name__)
 

--- a/src/josepy/util.py
+++ b/src/josepy/util.py
@@ -1,5 +1,8 @@
 """JOSE utilities."""
-import collections
+try:
+    from collections.abc import Hashable, Mapping  # pylint: disable=import-error
+except ImportError:
+    from collections import Hashable, Mapping
 
 import OpenSSL
 import six
@@ -135,7 +138,7 @@ class ComparableRSAKey(ComparableKey):  # pylint: disable=too-few-public-methods
             return hash((self.__class__, pub.n, pub.e))
 
 
-class ImmutableMap(collections.Mapping, collections.Hashable):  # type: ignore
+class ImmutableMap(Mapping, Hashable):  # type: ignore
     # pylint: disable=too-few-public-methods
     """Immutable key to value mapping with attribute access."""
 
@@ -181,7 +184,7 @@ class ImmutableMap(collections.Mapping, collections.Hashable):  # type: ignore
             for key, value in six.iteritems(self)))
 
 
-class frozendict(collections.Mapping, collections.Hashable):  # type: ignore
+class frozendict(Mapping, Hashable):  # type: ignore
     # pylint: disable=invalid-name,too-few-public-methods
     """Frozen dictionary."""
     __slots__ = ('_items', '_keys')
@@ -189,7 +192,7 @@ class frozendict(collections.Mapping, collections.Hashable):  # type: ignore
     def __init__(self, *args, **kwargs):
         if kwargs and not args:
             items = dict(kwargs)
-        elif len(args) == 1 and isinstance(args[0], collections.Mapping):
+        elif len(args) == 1 and isinstance(args[0], Mapping):
             items = args[0]
         else:
             raise TypeError()


### PR DESCRIPTION
Starting with Python 3.8, abstract types from `collections` will need to be imported from the `collections.abc`. Currently on recent versions of Python, theses types can be imported both from `collections` and `collections.abc`, but will generated a warning about support drop for Python 3.8 if `collections` is used.

This PR allows to use `collections.abc`, and falls back to `collections` if necessary.