### PR TITLE
Don't require sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ matrix:
     - python: "3.6"
     - dist: xenial
       python: "3.7"
-      sudo: true
 install:
   - pip install tox-travis codecov
 script:


### PR DESCRIPTION
Now that Travis has real [Xenial support](https://docs.travis-ci.com/user/reference/xenial/) we don't need to use `sudo: true` which should speed up the build slightly.