### PR TITLE
Always use xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: python
 sudo: false
 cache: pip
+dist: xenial
 matrix:
   include:
     - python: "2.7"
     - python: "3.4"
     - python: "3.5"
     - python: "3.6"
-    - dist: xenial
-      python: "3.7"
+    - python: "3.7"
       sudo: true
 install:
   - pip install tox-travis codecov


### PR DESCRIPTION
Now that Travis has real [Xenial support](https://docs.travis-ci.com/user/reference/xenial/), I figure we might as well use it for all environments to get later and greater versions of software and simplify the Travis config.