### PR TITLE
Change build status links to travis-ci.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 JOSE protocol implementation in Python using cryptography
 
-.. image:: https://travis-ci.org/certbot/josepy.svg?branch=master
-  :target: https://travis-ci.org/certbot/josepy
+.. image:: https://travis-ci.com/certbot/josepy.svg?branch=master
+  :target: https://travis-ci.com/certbot/josepy
 
 .. image:: https://codecov.io/gh/certbot/josepy/branch/master/graph/badge.svg
   :target: https://codecov.io/gh/certbot/josepy


### PR DESCRIPTION
As part of migrating away from the now deprecated support for GitHub services, our Travis config has moved from travis-ci.org to travis-ci.com. This PR updates the links to our build status to use travis-ci.com.