### PR TITLE
Temporarily remove isort

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-addopts = -v --flake8 --isort --cov-report xml --cov-report=term-missing --cov=josepy --cov-config .coveragerc
+addopts = -v --flake8 --cov-report xml --cov-report=term-missing --cov=josepy --cov-config .coveragerc
 norecursedirs = *.egg .eggs dist build docs .tox
 flake8-ignore = W504 E501

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ install_requires = [
 
 testing_requires = [
     'coverage>=4.0',
-    'pytest-isort',
     'pytest-cache>=1.0',
     'pytest-cov',
     'flake8',


### PR DESCRIPTION
As you can see at https://github.com/certbot/josepy/runs/75221064, we're having some problems with `isort`.

It seems the new version is no longer properly recognizing that `josepy` is a first party library and it's not happy with our `__init__.py` file. Let's just remove these checks for now so tests pass again.