### PR TITLE
Add IRC channel notifications.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,3 @@ notifications:
     on_cancel: never
     on_success: never
     on_failure: always
-    use_notice: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,14 @@ after_success:
   - codecov
 notifications:
   email: false
+  irc:
+    channels:
+      # This is set to a secure variable to prevent forks from sending
+      # notifications. This value was created by installing
+      # https://github.com/travis-ci/travis.rb and running
+      # `travis encrypt "chat.freenode.net#certbot-devel"`.
+      - secure: "JDbizbq58cmpQ3hbq9/PT4V0mns9jJ9oa/fF9P/e3raZkqm3APDcfVx79QiIDXShFsy4DYYZDTTPn4yuGhzX29Wo5z0ncWmMaPJP1+BnKxgh1Zit8TcG0doFXjc5A3RRXAEYRkb4ffwJtmWor/hN8fRwFFivg6yH/54I/XWUT12/nlXaMG+hygndkI9Rmg9REVd4/sScBR25xBh6bkTcG/szMZugpvJeZsbjjxaXrZxo2270wvdiUHGaGffgEVhCHuMMN8bs/5qeM1GMGohQVwqXciBZKUJ51C3YQl61O09SoJxPOjvik+6Os2iiQBkMmKiPTLpvpeXZMDVXM3tVUiLHckmSnuT6FHI4lmpNl0/qPGGlmvNL7PeUuZ+Mcry8meeSwM/3nYSAp4UZC4lojiR221fHIQiT67yUOAYxyaDoTs33QWQT8VE1FkY81DBB+pdcm2E1pgzfTLLTvprEZL+vabVr2ayvvQnTnTg8FKkulLFYDu0IZ2e68+TDULLkPfEUTQMVxq1Xv5cBza1USnF/Mee3x3I8niiHEaC2fDuNRENdQv6hMqcocHy7QiWTPACI/PJjO1CuYfN0QPpuHemxxyZSLrLy7kAnmmcMgUGCnorWcruc53FImsSZzFVAwe8th2iFgHKDPjlWFwB9xjCfgzNpGal85q8S6dVex1E="
+    on_cancel: never
+    on_success: never
+    on_failure: always
+    use_notice: true


### PR DESCRIPTION
I tested this at https://travis-ci.com/certbot/josepy/builds/113496549 which successfully sent a notification to the new channel. @joohoi, I believe you were in the channel to see this message, but if not, we can trigger the build again.

Because I had to look up how to do this again, I added a comment describing how this value was created.