### PR TITLE
Add support for Python 3.8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
     - python: "3.5"
     - python: "3.6"
     - python: "3.7"
+    - python: "3.8-dev"
 install:
   - pip install tox-travis codecov
 script:

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Security',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py27
-    py3{4,5,6,7}
+    py3{4,5,6,7,8}
 
 [testenv]
 commands =


### PR DESCRIPTION
Certbot supports Python 3.8 so josepy needs to as well.