### PR TITLE
Don't use the development branch of Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     - python: "3.5"
     - python: "3.6"
     - python: "3.7"
-    - python: "3.8-dev"
+    - python: "3.8"
 install:
   - pip install tox-travis codecov
 script:


### PR DESCRIPTION
We were previously using `python: 3.8-dev` to allow us to test against Python 3.8 before it was released. Now that Python 3.8 is out and the development branch is [causing errors for us](https://travis-ci.com/certbot/josepy/jobs/286198517), let's just use the stable version of Python 3.8.