### PR TITLE
Pin flake8/all Python dependencies in tests

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,21 +1,33 @@
-# Specifies Python package versions for development and testing.
-# To generate:
-# python3 -m venv venv3 && source venv3/bin/activate
+# Specifies Python package versions for testing.
+# To update:
+# python3 -m venv venv && source venv/bin/activate
 # python3 -m pip install -e .[dev,tests] && pip freeze
+# Examine the produced list and update invididual entries here.
 # If anything changes about this file's contents or location, we may
 # need to submit a PR to pyca/cryptography, since they rely on it.
 
 apipkg==1.5
+atomicwrites==1.4.0
 attrs==19.3.0
 cffi==1.14.0
+configparser==4.0.2
+contextlib2==0.6.0.post1
 coverage==5.1
 cryptography==2.9.2
+entrypoints==0.3
+enum34==1.1.10
 execnet==1.7.1
 flake8==3.7.9
+funcsigs==1.0.2
+functools32==3.2.3.post2
+importlib-metadata==1.6.0
+ipaddress==1.0.23
 mccabe==0.6.1
 mock==1.3.0
 more-itertools==5.0.0
 packaging==20.3
+pathlib2==2.3.5
+pbr==5.4.5
 pluggy==0.13.1
 py==1.8.1
 pycodestyle==2.5.0
@@ -27,5 +39,8 @@ pytest==4.6.10
 pytest-cache==1.0
 pytest-cov==2.8.1
 pytest-flake8==1.0.5
+scandir==1.10.0
 six==1.14.0
+typing==3.7.4.1
 wcwidth==0.1.9
+zipp==1.2.0

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,31 @@
+# Specifies Python package versions for development and testing.
+# To generate:
+# python3 -m venv venv3 && source venv3/bin/activate
+# python3 -m pip install -e .[dev,tests] && pip freeze
+# If anything changes about this file's contents or location, we may
+# need to submit a PR to pyca/cryptography, since they rely on it.
+
+apipkg==1.5
+attrs==19.3.0
+cffi==1.14.0
+coverage==5.1
+cryptography==2.9.2
+execnet==1.7.1
+flake8==3.7.9
+mccabe==0.6.1
+mock==1.3.0
+more-itertools==5.0.0
+packaging==20.3
+pluggy==0.13.1
+py==1.8.1
+pycodestyle==2.5.0
+pycparser==2.20
+pyflakes==2.1.1
+pyOpenSSL==19.1.0
+pyparsing==2.4.7
+pytest==4.6.10
+pytest-cache==1.0
+pytest-cov==2.8.1
+pytest-flake8==1.0.5
+six==1.14.0
+wcwidth==0.1.9

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,20 +1,12 @@
-<<<<<<< HEAD
 # Specifies Python package versions for testing.
 # To update:
 # python3 -m venv venv && source venv/bin/activate
 # python3 -m pip install -e .[dev,tests] && pip freeze
 # Examine the produced list and update invididual entries here.
-=======
-# Specifies Python package versions for development and testing.
-# To generate:
-# python3 -m venv venv3 && source venv3/bin/activate
-# python3 -m pip install -e .[dev,tests] && pip freeze
->>>>>>> 59469f554a54f6c88e9800003035bce5d589c29c
 # If anything changes about this file's contents or location, we may
 # need to submit a PR to pyca/cryptography, since they rely on it.
 
 apipkg==1.5
-<<<<<<< HEAD
 atomicwrites==1.4.0
 attrs==19.3.0
 cffi==1.14.0
@@ -30,23 +22,12 @@ funcsigs==1.0.2
 functools32==3.2.3.post2
 importlib-metadata==1.6.0
 ipaddress==1.0.23
-=======
-attrs==19.3.0
-cffi==1.14.0
-coverage==5.1
-cryptography==2.9.2
-execnet==1.7.1
-flake8==3.7.9
->>>>>>> 59469f554a54f6c88e9800003035bce5d589c29c
 mccabe==0.6.1
 mock==1.3.0
 more-itertools==5.0.0
 packaging==20.3
-<<<<<<< HEAD
 pathlib2==2.3.5
 pbr==5.4.5
-=======
->>>>>>> 59469f554a54f6c88e9800003035bce5d589c29c
 pluggy==0.13.1
 py==1.8.1
 pycodestyle==2.5.0
@@ -58,13 +39,8 @@ pytest==4.6.10
 pytest-cache==1.0
 pytest-cov==2.8.1
 pytest-flake8==1.0.5
-<<<<<<< HEAD
 scandir==1.10.0
 six==1.14.0
 typing==3.7.4.1
 wcwidth==0.1.9
 zipp==1.2.0
-=======
-six==1.14.0
-wcwidth==0.1.9
->>>>>>> 59469f554a54f6c88e9800003035bce5d589c29c

--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,9 @@ envlist =
 [testenv]
 commands =
     py.test {posargs}
-deps:
-    # installs the test dependencies as specified in setup.py
-    .[tests]
+deps =
+    -cconstraints.txt
+    -e .[tests]
 
 [flake8]
 ignore = W504, E501


### PR DESCRIPTION
Fixes #63.

Took some finagling to get a working set of dependencies. Some I copied from Certbot, some are based on going back through releases to find a compatible set.