### PR TITLE
Deprecate Python 3.5 support

### DIFF
--- a/src/josepy/__init__.py
+++ b/src/josepy/__init__.py
@@ -25,6 +25,9 @@ Originally developed as part of the ACME_ protocol implementation.
 .. _ACME: https://pypi.python.org/pypi/acme
 
 """
+import sys
+import warning
+
 # flake8: noqa
 from josepy.b64 import (
     b64decode,
@@ -84,3 +87,10 @@ from josepy.util import (
     ComparableRSAKey,
     ImmutableMap,
 )
+
+if sys.version_info[:2] == (3, 5):
+    warnings.warn(
+            "Python 3.5 support will be dropped in the next release of "
+            "josepy. Please upgrade your Python version.",
+            DeprecationWarning,
+    )

--- a/src/josepy/__init__.py
+++ b/src/josepy/__init__.py
@@ -26,7 +26,7 @@ Originally developed as part of the ACME_ protocol implementation.
 
 """
 import sys
-import warning
+import warnings
 
 # flake8: noqa
 from josepy.b64 import (


### PR DESCRIPTION
Now that Certbot no longer supports Python 3.5 which is EOL'd next month, let's deprecate it here. Once this lands, I'll try to squeeze in a release this package and then we can drop Python 3.5 support in master.

This was based on #56.