### PR TITLE
Drop Python 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ dist: xenial
 matrix:
   include:
     - python: "2.7"
-    - python: "3.5"
     - python: "3.6"
     - python: "3.7"
     - python: "3.8"

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
     author="Certbot Project",
     author_email='client-dev@letsencrypt.org',
     license='Apache License 2.0',
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*',
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
@@ -81,7 +81,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/src/josepy/__init__.py
+++ b/src/josepy/__init__.py
@@ -25,9 +25,6 @@ Originally developed as part of the ACME_ protocol implementation.
 .. _ACME: https://pypi.python.org/pypi/acme
 
 """
-import sys
-import warnings
-
 # flake8: noqa
 from josepy.b64 import (
     b64decode,
@@ -87,10 +84,3 @@ from josepy.util import (
     ComparableRSAKey,
     ImmutableMap,
 )
-
-if sys.version_info[:2] == (3, 5):
-    warnings.warn(
-            "Python 3.5 support will be dropped in the next release of "
-            "josepy. Please upgrade your Python version.",
-            DeprecationWarning,
-    )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py27
-    py3{5,6,7,8}
+    py3{6,7,8}
 
 [testenv]
 commands =


### PR DESCRIPTION
Now that [josepy 1.4.0](https://pypi.org/project/josepy/1.4.0/) is out deprecating Python 3.5 support, let's drop support for it in `master`. This PR is based on #58.