### PR TITLE
Deprecate support for Python 2.7

### DIFF
--- a/src/josepy/__init__.py
+++ b/src/josepy/__init__.py
@@ -25,6 +25,9 @@ Originally developed as part of the ACME_ protocol implementation.
 .. _ACME: https://pypi.python.org/pypi/acme
 
 """
+import sys
+import warnings
+
 # flake8: noqa
 from josepy.b64 import (
     b64decode,
@@ -84,3 +87,10 @@ from josepy.util import (
     ComparableRSAKey,
     ImmutableMap,
 )
+
+if sys.version_info[:2] == (2, 7):
+    warnings.warn(
+            "Python 2.7 support will be dropped in the next release of "
+            "josepy. Please upgrade your Python version.",
+            DeprecationWarning,
+    )


### PR DESCRIPTION
This was based on https://github.com/certbot/josepy/pull/67.

Once this PR is merged and included in a release, we can drop Python 2.7 support here as well.