### PR TITLE
Stop using the development branch of Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     - python: "3.6"
     - python: "3.7"
     - python: "3.8"
-    - python: "3.9-dev"
+    - python: "3.9"
 install:
   - pip install tox-travis codecov
 script:


### PR DESCRIPTION
We originally used `3.9-dev` here so we could test Python 3.9 support before it was released and offered by Travis. Now Travis offers the stable version of Python 3.9 though so I don't think we need to or should be testing using the development branch of Python 3.9 anymore.

More about the Python versions offered by Travis can be found at https://docs.travis-ci.com/user/languages/python/#specifying-python-versions.