### PR TITLE
Updated unittest assert to Python 3 support.

### DIFF
--- a/src/josepy/interfaces_test.py
+++ b/src/josepy/interfaces_test.py
@@ -66,7 +66,7 @@ class JSONDeSerializableTest(unittest.TestCase):
 
     def test_to_json_other(self):
         mock_value = object()
-        self.assertTrue(self.Basic(mock_value).to_json() is mock_value)
+        self.assertIs(self.Basic(mock_value).to_json(), mock_value)
 
     def test_to_json_nested(self):
         self.assertEqual(self.nested.to_json(), [['foo1']])
@@ -80,9 +80,9 @@ class JSONDeSerializableTest(unittest.TestCase):
 
     def test_json_loads(self):
         seq = self.Sequence.json_loads('["foo1", "foo2"]')
-        self.assertTrue(isinstance(seq, self.Sequence))
-        self.assertTrue(isinstance(seq.x, self.Basic))
-        self.assertTrue(isinstance(seq.y, self.Basic))
+        self.assertIsInstance(seq, self.Sequence)
+        self.assertIsInstance(seq.x, self.Basic)
+        self.assertIsInstance(seq.y, self.Basic)
         self.assertEqual(seq.x.v, 'foo1')
         self.assertEqual(seq.y.v, 'foo2')
 
@@ -101,8 +101,8 @@ class JSONDeSerializableTest(unittest.TestCase):
 
         jobj = JSONDeSerializable.json_dump_default(self.seq)
         self.assertEqual(len(jobj), 2)
-        self.assertTrue(jobj[0] is self.basic1)
-        self.assertTrue(jobj[1] is self.basic2)
+        self.assertIs(jobj[0], self.basic1)
+        self.assertIs(jobj[1], self.basic2)
 
     def test_json_dump_default_type_error(self):
         from josepy.interfaces import JSONDeSerializable

--- a/src/josepy/json_util_test.py
+++ b/src/josepy/json_util_test.py
@@ -16,8 +16,8 @@ class FieldTest(unittest.TestCase):
         from josepy.json_util import Field
         for default, omitempty, value in itertools.product(
                 [True, False], [True, False], [True, False]):
-            self.assertFalse(
-                Field("foo", default=default, omitempty=omitempty).omit(value))
+            self.assertIs(
+                Field("foo", default=default, omitempty=omitempty).omit(value), False)
 
     def test_descriptors(self):
         mock_value = mock.MagicMock()
@@ -52,14 +52,14 @@ class FieldTest(unittest.TestCase):
         mock_field = MockField()
 
         from josepy.json_util import Field
-        self.assertTrue(Field.default_encoder(mock_field) is mock_field)
+        self.assertIs(Field.default_encoder(mock_field), mock_field)
         # in particular...
         self.assertNotEqual('foo', Field.default_encoder(mock_field))
 
     def test_default_encoder_passthrough(self):
         mock_value = mock.MagicMock()
         from josepy.json_util import Field
-        self.assertTrue(Field.default_encoder(mock_value) is mock_value)
+        self.assertIs(Field.default_encoder(mock_value), mock_value)
 
     def test_default_decoder_list_to_tuple(self):
         from josepy.json_util import Field
@@ -68,13 +68,13 @@ class FieldTest(unittest.TestCase):
     def test_default_decoder_dict_to_frozendict(self):
         from josepy.json_util import Field
         obj = Field.default_decoder({'x': 2})
-        self.assertTrue(isinstance(obj, util.frozendict))
+        self.assertIsInstance(obj, util.frozendict)
         self.assertEqual(obj, util.frozendict(x=2))
 
     def test_default_decoder_passthrough(self):
         mock_value = mock.MagicMock()
         from josepy.json_util import Field
-        self.assertTrue(Field.default_decoder(mock_value) is mock_value)
+        self.assertIs(Field.default_decoder(mock_value), mock_value)
 
 
 class JSONObjectWithFieldsMetaTest(unittest.TestCase):
@@ -243,13 +243,13 @@ class DeEncodersTest(unittest.TestCase):
     def test_encode_b64jose(self):
         from josepy.json_util import encode_b64jose
         encoded = encode_b64jose(b'x')
-        self.assertTrue(isinstance(encoded, str))
+        self.assertIsInstance(encoded, str)
         self.assertEqual(u'eA', encoded)
 
     def test_decode_b64jose(self):
         from josepy.json_util import decode_b64jose
         decoded = decode_b64jose(u'eA')
-        self.assertTrue(isinstance(decoded, bytes))
+        self.assertIsInstance(decoded, bytes)
         self.assertEqual(b'x', decoded)
 
     def test_decode_b64jose_padding_error(self):
@@ -275,13 +275,13 @@ class DeEncodersTest(unittest.TestCase):
         from josepy.json_util import encode_hex16
         encoded = encode_hex16(b'foo')
         self.assertEqual(u'666f6f', encoded)
-        self.assertTrue(isinstance(encoded, str))
+        self.assertIsInstance(encoded, str)
 
     def test_decode_hex16(self):
         from josepy.json_util import decode_hex16
         decoded = decode_hex16(u'666f6f')
         self.assertEqual(b'foo', decoded)
-        self.assertTrue(isinstance(decoded, bytes))
+        self.assertIsInstance(decoded, bytes)
 
     def test_decode_hex16_minimum_size(self):
         from josepy.json_util import decode_hex16
@@ -301,7 +301,7 @@ class DeEncodersTest(unittest.TestCase):
     def test_decode_cert(self):
         from josepy.json_util import decode_cert
         cert = decode_cert(self.b64_cert)
-        self.assertTrue(isinstance(cert, util.ComparableX509))
+        self.assertIsInstance(cert, util.ComparableX509)
         self.assertEqual(cert, CERT)
         self.assertRaises(errors.DeserializationError, decode_cert, u'')
 
@@ -312,7 +312,7 @@ class DeEncodersTest(unittest.TestCase):
     def test_decode_csr(self):
         from josepy.json_util import decode_csr
         csr = decode_csr(self.b64_csr)
-        self.assertTrue(isinstance(csr, util.ComparableX509))
+        self.assertIsInstance(csr, util.ComparableX509)
         self.assertEqual(csr, CSR)
         self.assertRaises(errors.DeserializationError, decode_csr, u'')
 

--- a/src/josepy/jwa_test.py
+++ b/src/josepy/jwa_test.py
@@ -51,7 +51,7 @@ class JWASignatureTest(unittest.TestCase):
     def test_from_json(self):
         from josepy.jwa import JWASignature
         from josepy.jwa import RS256
-        self.assertTrue(JWASignature.from_json('RS256') is RS256)
+        self.assertIs(JWASignature.from_json('RS256'), RS256)
 
 
 class JWAHSTest(unittest.TestCase):  # pylint: disable=too-few-public-methods
@@ -63,8 +63,8 @@ class JWAHSTest(unittest.TestCase):  # pylint: disable=too-few-public-methods
             b"\r\x85+\x0e\x85\xaeUZ\xd4\xb3\x97zO"
         )
         self.assertEqual(HS256.sign(b'some key', b'foo'), sig)
-        self.assertTrue(HS256.verify(b'some key', b'foo', sig) is True)
-        self.assertTrue(HS256.verify(b'some key', b'foo', sig + b'!') is False)
+        self.assertIs(HS256.verify(b'some key', b'foo', sig), True)
+        self.assertIs(HS256.verify(b'some key', b'foo', sig + b'!'), False)
 
 
 class JWARSTest(unittest.TestCase):
@@ -88,22 +88,22 @@ class JWARSTest(unittest.TestCase):
             b'\xd2\xb9.>}\xfd'
         )
         self.assertEqual(RS256.sign(RSA512_KEY, b'foo'), sig)
-        self.assertTrue(RS256.verify(RSA512_KEY.public_key(), b'foo', sig))
-        self.assertFalse(RS256.verify(
-            RSA512_KEY.public_key(), b'foo', sig + b'!'))
+        self.assertIs(RS256.verify(RSA512_KEY.public_key(), b'foo', sig), True)
+        self.assertIs(RS256.verify(
+            RSA512_KEY.public_key(), b'foo', sig + b'!'), False)
 
     def test_ps(self):
         from josepy.jwa import PS256
         sig = PS256.sign(RSA1024_KEY, b'foo')
-        self.assertTrue(PS256.verify(RSA1024_KEY.public_key(), b'foo', sig))
-        self.assertFalse(PS256.verify(
-            RSA1024_KEY.public_key(), b'foo', sig + b'!'))
+        self.assertIs(PS256.verify(RSA1024_KEY.public_key(), b'foo', sig), True)
+        self.assertIs(PS256.verify(
+            RSA1024_KEY.public_key(), b'foo', sig + b'!'), False)
 
     def test_sign_new_api(self):
         from josepy.jwa import RS256
         key = mock.MagicMock()
         RS256.sign(key, "message")
-        self.assertTrue(key.sign.called)
+        self.assertIs(key.sign.called, True)
 
     def test_sign_old_api(self):
         from josepy.jwa import RS256
@@ -111,16 +111,15 @@ class JWARSTest(unittest.TestCase):
         signer = mock.MagicMock()
         key.signer.return_value = signer
         RS256.sign(key, "message")
-        self.assertTrue(all([
-            key.signer.called,
-            signer.update.called,
-            signer.finalize.called]))
+        self.assertIs(key.signer.called, True)
+        self.assertIs(signer.update.called, True)
+        self.assertIs(signer.finalize.called, True)
 
     def test_verify_new_api(self):
         from josepy.jwa import RS256
         key = mock.MagicMock()
         RS256.verify(key, "message", "signature")
-        self.assertTrue(key.verify.called)
+        self.assertIs(key.verify.called, True)
 
     def test_verify_old_api(self):
         from josepy.jwa import RS256
@@ -128,10 +127,9 @@ class JWARSTest(unittest.TestCase):
         verifier = mock.MagicMock()
         key.verifier.return_value = verifier
         RS256.verify(key, "message", "signature")
-        self.assertTrue(all([
-            key.verifier.called,
-            verifier.update.called,
-            verifier.verify.called]))
+        self.assertIs(key.verifier.called, True)
+        self.assertIs(verifier.update.called, True)
+        self.assertIs(verifier.verify.called, True)
 
 
 class JWAECTest(unittest.TestCase):
@@ -145,19 +143,19 @@ class JWAECTest(unittest.TestCase):
         from josepy.jwa import ES256
         message = b'foo'
         signature = ES256.sign(EC_P256_KEY, message)
-        self.assertTrue(ES256.verify(EC_P256_KEY.public_key(), message, signature))
+        self.assertIs(ES256.verify(EC_P256_KEY.public_key(), message, signature), True)
 
     def test_es384_sign_and_verify(self):
         from josepy.jwa import ES384
         message = b'foo'
         signature = ES384.sign(EC_P384_KEY, message)
-        self.assertTrue(ES384.verify(EC_P384_KEY.public_key(), message, signature))
+        self.assertIs(ES384.verify(EC_P384_KEY.public_key(), message, signature), True)
 
     def test_verify_with_wrong_jwa(self):
         from josepy.jwa import ES256, ES384
         message = b'foo'
         signature = ES256.sign(EC_P256_KEY, message)
-        self.assertFalse(ES384.verify(EC_P384_KEY.public_key(), message, signature))
+        self.assertIs(ES384.verify(EC_P384_KEY.public_key(), message, signature), False)
 
     def test_verify_with_different_key(self):
         from josepy.jwa import ES256
@@ -167,7 +165,7 @@ class JWAECTest(unittest.TestCase):
         message = b'foo'
         signature = ES256.sign(EC_P256_KEY, message)
         different_key = ec.generate_private_key(ec.SECP256R1, default_backend())
-        self.assertFalse(ES256.verify(different_key.public_key(), message, signature))
+        self.assertIs(ES256.verify(different_key.public_key(), message, signature), False)
 
     def test_sign_new_api(self):
         from josepy.jwa import ES256
@@ -175,7 +173,7 @@ class JWAECTest(unittest.TestCase):
         with mock.patch("josepy.jwa.decode_dss_signature") as decode_patch:
             decode_patch.return_value = (0, 0)
             ES256.sign(key, "message")
-        self.assertTrue(key.sign.called)
+        self.assertIs(key.sign.called, True)
 
     def test_sign_old_api(self):
         from josepy.jwa import ES256
@@ -185,16 +183,15 @@ class JWAECTest(unittest.TestCase):
         with mock.patch("josepy.jwa.decode_dss_signature") as decode_patch:
             decode_patch.return_value = (0, 0)
             ES256.sign(key, "message")
-        self.assertTrue(all([
-            key.signer.called,
-            signer.update.called,
-            signer.finalize.called]))
+        self.assertIs(key.signer.called, True)
+        self.assertIs(signer.update.called, True)
+        self.assertIs(signer.finalize.called, True)
 
     def test_verify_new_api(self):
         from josepy.jwa import ES256
         key = mock.MagicMock()
         ES256.verify(key, "message", "signature".encode())
-        self.assertTrue(key.verify.called)
+        self.assertIs(key.verify.called, True)
 
     def test_verify_old_api(self):
         from josepy.jwa import ES256
@@ -203,10 +200,9 @@ class JWAECTest(unittest.TestCase):
         key.verifier.return_value = verifier
         key.key_size = 65 * 8
         ES256.verify(key, "message", "signature".encode())
-        self.assertTrue(all([
-            key.verifier.called,
-            verifier.update.called,
-            verifier.verify.called]))
+        self.assertIs(key.verifier.called, True)
+        self.assertIs(verifier.update.called, True)
+        self.assertIs(verifier.verify.called, True)
 
 
 if __name__ == '__main__':

--- a/src/josepy/jwk_test.py
+++ b/src/josepy/jwk_test.py
@@ -64,7 +64,7 @@ class JWKOctTest(unittest.TestCase, JWKTestBaseMixin):
         self.assertEqual(self.jwk, JWKOct.load(b'foo'))
 
     def test_public_key(self):
-        self.assertTrue(self.jwk.public_key() is self.jwk)
+        self.assertIs(self.jwk.public_key(), self.jwk)
 
 
 class JWKRSATest(unittest.TestCase, JWKTestBaseMixin):
@@ -108,8 +108,7 @@ class JWKRSATest(unittest.TestCase, JWKTestBaseMixin):
         self.jwk = self.private
 
     def test_init_auto_comparable(self):
-        self.assertTrue(isinstance(
-            self.jwk256_not_comparable.key, util.ComparableRSAKey))
+        self.assertIsInstance(self.jwk256_not_comparable.key, util.ComparableRSAKey)
         self.assertEqual(self.jwk256, self.jwk256_not_comparable)
 
     def test_encode_param_zero(self):
@@ -226,8 +225,8 @@ class JWKECTest(unittest.TestCase, JWKTestBaseMixin):
         self.jwk = self.private
 
     def test_init_auto_comparable(self):
-        self.assertTrue(isinstance(
-            self.jwk256_not_comparable.key, util.ComparableECKey))
+        self.assertIsInstance(
+            self.jwk256_not_comparable.key, util.ComparableECKey)
         self.assertEqual(self.jwk256, self.jwk256_not_comparable)
 
     def test_encode_param_zero(self):

--- a/src/josepy/jws_test.py
+++ b/src/josepy/jws_test.py
@@ -116,13 +116,13 @@ class JWSTest(unittest.TestCase):
         self.assertEqual(self.mixed.signature.combined.jwk, self.pubkey)
 
     def test_sign_unprotected(self):
-        self.assertTrue(self.unprotected.verify())
+        self.assertIs(self.unprotected.verify(), True)
 
     def test_sign_protected(self):
-        self.assertTrue(self.protected.verify())
+        self.assertIs(self.protected.verify(), True)
 
     def test_sign_mixed(self):
-        self.assertTrue(self.mixed.verify())
+        self.assertIs(self.mixed.verify(), True)
 
     def test_compact_lost_unprotected(self):
         compact = self.mixed.to_compact()
@@ -146,8 +146,8 @@ class JWSTest(unittest.TestCase):
         protected_jobj = self.protected.to_partial_json(flat=True)
         unprotected_jobj = self.unprotected.to_partial_json(flat=True)
 
-        self.assertTrue('protected' not in unprotected_jobj)
-        self.assertTrue('header' not in protected_jobj)
+        self.assertNotIn('protected', unprotected_jobj)
+        self.assertNotIn('header', protected_jobj)
 
         unprotected_jobj['header'] = unprotected_jobj['header'].to_json()
 

--- a/src/josepy/magic_typing_test.py
+++ b/src/josepy/magic_typing_test.py
@@ -36,7 +36,7 @@ class MagicTypingTest(unittest.TestCase):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=DeprecationWarning)
             from josepy.magic_typing import Text  # pylint: disable=no-name-in-module
-        self.assertTrue(Text is None)
+        self.assertIsNone(Text)
         del sys.modules['josepy.magic_typing']
         sys.modules['typing'] = temp_typing
 

--- a/src/josepy/util_test.py
+++ b/src/josepy/util_test.py
@@ -20,7 +20,7 @@ class ComparableX509Test(unittest.TestCase):
         self.cert_other = test_util.load_comparable_cert('cert-san.pem')
 
     def test_getattr_proxy(self):
-        self.assertTrue(self.cert1.has_expired())
+        self.assertIs(self.cert1.has_expired(), True)
 
     def test_eq(self):
         self.assertEqual(self.req1, self.req2)
@@ -77,17 +77,17 @@ class ComparableRSAKeyTest(unittest.TestCase):
         self.assertNotEqual(ComparableRSAKey(5), ComparableRSAKey(5))
 
     def test_hash(self):
-        self.assertTrue(isinstance(hash(self.key), int))
+        self.assertIsInstance(hash(self.key), int)
         self.assertEqual(hash(self.key), hash(self.key_same))
         self.assertNotEqual(hash(self.key), hash(self.key2))
 
     def test_repr(self):
-        self.assertTrue(repr(self.key).startswith(
-            '<ComparableRSAKey(<cryptography.hazmat.'))
+        self.assertIs(repr(self.key).startswith(
+            '<ComparableRSAKey(<cryptography.hazmat.'), True)
 
     def test_public_key(self):
         from josepy.util import ComparableRSAKey
-        self.assertTrue(isinstance(self.key.public_key(), ComparableRSAKey))
+        self.assertIsInstance(self.key.public_key(), ComparableRSAKey)
 
 
 class ComparableECKeyTest(unittest.TestCase):
@@ -122,18 +122,18 @@ class ComparableECKeyTest(unittest.TestCase):
         self.assertNotEqual(ComparableECKey(5), ComparableECKey(5))
 
     def test_hash(self):
-        self.assertTrue(isinstance(hash(self.p256_key), int))
+        self.assertIsInstance(hash(self.p256_key), int)
         self.assertEqual(hash(self.p256_key), hash(self.p256_key_same))
         self.assertNotEqual(hash(self.p256_key), hash(self.p384_key))
         self.assertNotEqual(hash(self.p256_key), hash(self.p521_key))
 
     def test_repr(self):
-        self.assertTrue(repr(self.p256_key).startswith(
-            '<ComparableECKey(<cryptography.hazmat.'))
+        self.assertIs(repr(self.p256_key).startswith(
+            '<ComparableECKey(<cryptography.hazmat.'), True)
 
     def test_public_key(self):
         from josepy.util import ComparableECKey
-        self.assertTrue(isinstance(self.p256_key.public_key(), ComparableECKey))
+        self.assertIsInstance(self.p256_key.public_key(), ComparableECKey)
 
 
 class ImmutableMapTest(unittest.TestCase):
@@ -224,7 +224,7 @@ class frozendictTest(unittest.TestCase):  # pylint: disable=invalid-name
         self.assertEqual(2, len(self.fdict))
 
     def test_hash(self):
-        self.assertTrue(isinstance(hash(self.fdict), int))
+        self.assertIsInstance(hash(self.fdict), int)
 
     def test_getattr_proxy(self):
         self.assertEqual(1, self.fdict.x)


### PR DESCRIPTION
They provide better output and debugging. I split also a couple of instances of `assertTrue(all` to call `assertIs` for each of the statements.