### PR TITLE
collections.abc is supported on all supported Python versions.

### DIFF
--- a/src/josepy/interfaces.py
+++ b/src/josepy/interfaces.py
@@ -6,10 +6,7 @@ import six
 
 from josepy import errors, util
 
-try:
-    from collections.abc import Sequence, Mapping  # pylint: disable=import-error
-except ImportError:
-    from collections import Sequence, Mapping
+from collections.abc import Sequence, Mapping
 
 # pylint: disable=no-self-argument,no-method-argument,no-init,inherit-non-class
 # pylint: disable=too-few-public-methods

--- a/src/josepy/jwa.py
+++ b/src/josepy/jwa.py
@@ -17,10 +17,7 @@ from cryptography.hazmat.primitives.asymmetric.utils import encode_dss_signature
 
 from josepy import errors, interfaces, jwk
 
-try:
-    from collections.abc import Hashable  # pylint: disable=import-error
-except ImportError:
-    from collections import Hashable
+from collections.abc import Hashable
 
 logger = logging.getLogger(__name__)
 

--- a/src/josepy/util.py
+++ b/src/josepy/util.py
@@ -1,8 +1,5 @@
 """JOSE utilities."""
-try:
-    from collections.abc import Hashable, Mapping  # pylint: disable=import-error
-except ImportError:
-    from collections import Hashable, Mapping
+from collections.abc import Hashable, Mapping
 
 import OpenSSL
 import six


### PR DESCRIPTION
Should be good as of Python 3.3+ :) Will also increase code coverage slightly by removing some dead catch-blocks ;) 