### PR TITLE
Error on warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,6 @@
 [pytest]
 addopts = -v --flake8 --cov-report xml --cov-report=term-missing --cov=josepy --cov-config .coveragerc
+filterwarnings =
+    error
 norecursedirs = *.egg .eggs dist build docs .tox
 flake8-ignore = W504 E501


### PR DESCRIPTION
In the Certbot repo we configure `pytest` to error on warnings. See https://github.com/certbot/certbot/blob/d3ca6af9824d4715f4312724e32a26c270696db8/pytest.ini#L12-L13.

I think this is a good practice, I noticed we're not doing this here, and I think we should. Warnings are usually used to warn about things like uses of deprecated code and erroring on them ensures we see them and handle them appropriately.