### PR TITLE
Remove broken test for typing import failure

### DIFF
--- a/src/josepy/magic_typing_test.py
+++ b/src/josepy/magic_typing_test.py
@@ -25,21 +25,6 @@ class MagicTypingTest(unittest.TestCase):
         del sys.modules['josepy.magic_typing']
         sys.modules['typing'] = temp_typing
 
-    def test_import_failure(self):
-        try:
-            import typing as temp_typing
-        except ImportError:  # pragma: no cover
-            temp_typing = None  # pragma: no cover
-        sys.modules['typing'] = None
-        if 'josepy.magic_typing' in sys.modules:
-            del sys.modules['josepy.magic_typing']  # pragma: no cover
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=DeprecationWarning)
-            from josepy.magic_typing import Text  # pylint: disable=no-name-in-module
-        self.assertIsNone(Text)
-        del sys.modules['josepy.magic_typing']
-        sys.modules['typing'] = temp_typing
-
 
 if __name__ == '__main__':
     unittest.main()  # pragma: no cover


### PR DESCRIPTION
This test doesn't work with newer versions of `cryptography`. See https://github.com/certbot/josepy/pull/88#issuecomment-786911443.

Since `magic_typing` is deprecated and `typing` should always be available since we only support Python 3.6+, I think we should just delete this test.