### PR TITLE
JWKEC - key en/de-coding

### DIFF
--- a/src/josepy/jwa.py
+++ b/src/josepy/jwa.py
@@ -5,7 +5,6 @@ https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40
 """
 import abc
 import logging
-import math
 
 import cryptography.exceptions
 from cryptography.hazmat.backends import default_backend
@@ -172,7 +171,7 @@ class _JWAEC(JWASignature):
         """Sign the ``msg`` using ``key``."""
         sig = self._sign(key, msg)
         dr, ds = decode_dss_signature(sig)
-        length = math.ceil(key.key_size / 8)
+        length = jwk.JWKEC.expected_length_for_curve(key.curve)
         return (dr.to_bytes(length=length, byteorder='big') +
                 ds.to_bytes(length=length, byteorder='big'))
 
@@ -198,7 +197,7 @@ class _JWAEC(JWASignature):
 
     def verify(self, key, msg, sig):
         """Verify the ``msg` and ``sig`` using ``key``."""
-        rlen = math.ceil(key.key_size / 8)
+        rlen = jwk.JWKEC.expected_length_for_curve(key.curve)
         if len(sig) != 2 * rlen:
             # Format error - rfc7518 - 3.4 … MUST NOT be shortened to omit any leading zero octets
             return False

--- a/src/josepy/jwa_test.py
+++ b/src/josepy/jwa_test.py
@@ -169,7 +169,8 @@ class JWAECTest(unittest.TestCase):
 
     def test_sign_new_api(self):
         from josepy.jwa import ES256
-        key = mock.MagicMock()
+        from cryptography.hazmat.primitives.asymmetric.ec import SECP256R1
+        key = mock.MagicMock(curve=SECP256R1())
         with mock.patch("josepy.jwa.decode_dss_signature") as decode_patch:
             decode_patch.return_value = (0, 0)
             ES256.sign(key, "message")
@@ -177,7 +178,8 @@ class JWAECTest(unittest.TestCase):
 
     def test_sign_old_api(self):
         from josepy.jwa import ES256
-        key = mock.MagicMock(spec=[u'signer'], key_size=256)
+        from cryptography.hazmat.primitives.asymmetric.ec import SECP256R1
+        key = mock.MagicMock(spec=[u'signer'], curve=SECP256R1())
         signer = mock.MagicMock()
         key.signer.return_value = signer
         with mock.patch("josepy.jwa.decode_dss_signature") as decode_patch:
@@ -188,18 +190,21 @@ class JWAECTest(unittest.TestCase):
         self.assertIs(signer.finalize.called, True)
 
     def test_verify_new_api(self):
+        import math
         from josepy.jwa import ES256
-        key = mock.MagicMock(key_size=256)
-        ES256.verify(key, "message", b'\x00' * int(key.key_size / 8) * 2)
+        from cryptography.hazmat.primitives.asymmetric.ec import SECP256R1
+        key = mock.MagicMock(key_size=256, curve=SECP256R1())
+        ES256.verify(key, "message", b'\x00' * math.ceil(key.key_size / 8) * 2)
         self.assertIs(key.verify.called, True)
 
     def test_verify_old_api(self):
+        import math
         from josepy.jwa import ES256
-        key = mock.MagicMock(spec=[u'verifier'])
+        from cryptography.hazmat.primitives.asymmetric.ec import SECP521R1
+        key = mock.MagicMock(spec=[u'verifier'], key_size=521, curve=SECP521R1())
         verifier = mock.MagicMock()
         key.verifier.return_value = verifier
-        key.key_size = 65 * 8
-        ES256.verify(key, "message", b'\x00' * int(key.key_size / 8) * 2)
+        ES256.verify(key, "message", b'\x00' * math.ceil(key.key_size / 8) * 2)
         self.assertIs(key.verifier.called, True)
         self.assertIs(verifier.update.called, True)
         self.assertIs(verifier.verify.called, True)
@@ -210,8 +215,8 @@ class JWAECTest(unittest.TestCase):
         key = JWK.from_json(
             {
                 'd': 'Af9KP6DqLRbtit6NS_LRIaCP_-NdC5l5R2ugbILdfpv6dS9R4wUPNxiGw-vVWumA56Yo1oBnEm8ZdR4W-u1lPHw5',
-                'x': 'PiLhJPInTuJkmQeSkoQ64gKmfogeSfPACWt_7XDVrl2o6xF7fQQQJI3i8XFp4Ca10FIIoHAKruHWrhs-AysxS8U',
-                'y': 'cCVfGtpuNzH_IHEY5ueb8OQRAwkrUTr04djfHdXEXlVegpz3cIbgYuho--mFlC9me3kR8TFCg-S3A4whWEEdoVE',
+                'x': 'AD4i4STyJ07iZJkHkpKEOuICpn6IHknzwAlrf-1w1a5dqOsRe30EECSN4vFxaeAmtdBSCKBwCq7h1q4bPgMrMUvF',
+                'y': 'AHAlXxrabjcx_yBxGObnm_DkEQMJK1E69OHY3x3VxF5VXoKc93CG4GLoaPvphZQvZnt5EfExQoPktwOMIVhBHaFR',
                 'crv': 'P-521',
                 'kty': 'EC'
             })

--- a/src/josepy/jwk.py
+++ b/src/josepy/jwk.py
@@ -316,7 +316,7 @@ class JWKEC(JWK):
         raise errors.DeserializationError()
 
     @classmethod
-    def _expected_length_for_curve(cls, curve):
+    def expected_length_for_curve(cls, curve):
         if isinstance(curve, ec.SECP256R1):
             return 32
         elif isinstance(curve, ec.SECP384R1):
@@ -337,7 +337,7 @@ class JWKEC(JWK):
                 'Supplied key is neither of type EllipticCurvePublicKey nor EllipticCurvePrivateKey')
         params['x'] = public.x
         params['y'] = public.y
-        params = {key: self._encode_param(value, self._expected_length_for_curve(public.curve)) for key, value in params.items()}
+        params = {key: self._encode_param(value, self.expected_length_for_curve(public.curve)) for key, value in params.items()}
         params['crv'] = self._curve_name_to_crv(public.curve.name)
         return params
 
@@ -345,7 +345,7 @@ class JWKEC(JWK):
     def fields_from_json(cls, jobj):
         # pylint: disable=invalid-name
         curve = cls._crv_to_curve(jobj['crv'])
-        expected_length = cls._expected_length_for_curve(curve)
+        expected_length = cls.expected_length_for_curve(curve)
         x, y = (cls._decode_param(jobj[n], n, expected_length) for n in ('x', 'y'))
         public_numbers = ec.EllipticCurvePublicNumbers(x=x, y=y, curve=curve)
         if 'd' not in jobj:  # public key

--- a/src/josepy/jwk.py
+++ b/src/josepy/jwk.py
@@ -271,13 +271,12 @@ class JWKEC(JWK):
         super(JWKEC, self).__init__(*args, **kwargs)
 
     @classmethod
-    def _encode_param(cls, data, key_size):
+    def _encode_param(cls, data, length):
         """Encode Base64urlUInt.
         :type data: long
         :type key_size: long
         :rtype: unicode
         """
-        length = math.ceil(key_size / 8)
         return json_util.encode_b64jose(data.to_bytes(byteorder="big", length=length))
 
     @classmethod
@@ -338,7 +337,7 @@ class JWKEC(JWK):
                 'Supplied key is neither of type EllipticCurvePublicKey nor EllipticCurvePrivateKey')
         params['x'] = public.x
         params['y'] = public.y
-        params = {key: self._encode_param(value, self.key.key_size) for key, value in params.items()}
+        params = {key: self._encode_param(value, self._expected_length_for_curve(public.curve)) for key, value in params.items()}
         params['crv'] = self._curve_name_to_crv(public.curve.name)
         return params
 

--- a/src/josepy/jwk_test.py
+++ b/src/josepy/jwk_test.py
@@ -212,7 +212,7 @@ class JWKECTest(unittest.TestCase, JWKTestBaseMixin):
         self.jwk521json = {
             'kty': 'EC',
             'crv': 'P-521',
-            'x': 'WR2XpwrMGY_XxTx99-k_ghk3Z4QPjmENzBE-Xll4KXAdwu2cwEy5ZgUU783OboMvYyGk3TMjZtwwsl33lpja0-w',
+            'x': 'AFkdl6cKzBmP18U8fffpP4IZN2eED45hDcwRPl5ZeClwHcLtnMBMuWYFFO_Nzm6DL2MhpN0zI2bcMLJd95aY2tPs',
             'y': 'AYvZq3wByjt7nQd8nYMqhFNCL3j_-U6GPWZet1hYBY_XZHrC4yIV0R4JnssRAY9eqc1EElpCc4hziis1jiV1iR4W',
         }
         self.private = JWKEC(key=EC_P256_KEY)
@@ -233,7 +233,7 @@ class JWKECTest(unittest.TestCase, JWKTestBaseMixin):
         from josepy.jwk import JWKEC
         # pylint: disable=protected-access
         # TODO: move encode/decode _param to separate class
-        self.assertEqual('AA', JWKEC._encode_param(0))
+        self.assertEqual('AA', JWKEC._encode_param(0, 1))
 
     def test_equals(self):
         self.assertEqual(self.jwk256, self.jwk256)
@@ -303,6 +303,22 @@ class JWKECTest(unittest.TestCase, JWKTestBaseMixin):
                            'crv': 'P-255',
                            'x': 'jjQtV-fA7J_tK8dPzYq7jRPNjF8r5p6LW2R25S2Gw5U',
                            'y': 'EPAw8_8z7PYKsHH6hlGSlsWxFoFl7-0vM0QRGbmnvCc'})
+
+
+    def test_encode_y_leading_zero_p256(self):
+        from josepy.jwk import JWKEC,JWK
+        import josepy
+        data = b"""-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEICZ7LCI99Na2KZ/Fq8JmJROakGJ5+J7rHiGSPoO36kOAoAoGCCqGSM49
+AwEHoUQDQgAEGS5RvStca15z2FEanCM3juoX7tE/LB7iD44GWawGE40APAl/iZuH
+31wQfst4glTZpxkpEI/MzNZHjiYnqrGeSw==
+-----END EC PRIVATE KEY-----"""
+        key = JWKEC.load(data)
+        data = key.to_partial_json()
+        y = josepy.json_util.decode_b64jose(data['y'])
+        self.assertEqual(y[0], 0)
+        self.assertEqual(len(y), 32)
+        JWK.from_json(data)
 
 
 if __name__ == '__main__':

--- a/src/josepy/jwk_test.py
+++ b/src/josepy/jwk_test.py
@@ -304,9 +304,8 @@ class JWKECTest(unittest.TestCase, JWKTestBaseMixin):
                            'x': 'jjQtV-fA7J_tK8dPzYq7jRPNjF8r5p6LW2R25S2Gw5U',
                            'y': 'EPAw8_8z7PYKsHH6hlGSlsWxFoFl7-0vM0QRGbmnvCc'})
 
-
     def test_encode_y_leading_zero_p256(self):
-        from josepy.jwk import JWKEC,JWK
+        from josepy.jwk import JWKEC, JWK
         import josepy
         data = b"""-----BEGIN EC PRIVATE KEY-----
 MHcCAQEEICZ7LCI99Na2KZ/Fq8JmJROakGJ5+J7rHiGSPoO36kOAoAoGCCqGSM49


### PR DESCRIPTION
Hi,

this patch changes the encoding of ec coordinate parameters to be static in length according to rfc.

Without this patch there is a chance to run into
```
Deserialization error: Expected parameter "{x,y}" to be range(a, b) bytes after base64-decoding; got c bytes instead
```