### PR TITLE
Updated Python dict-constructs to Python 3.6+.

### DIFF
--- a/src/josepy/interfaces.py
+++ b/src/josepy/interfaces.py
@@ -143,8 +143,8 @@ class JSONDeSerializable(object, metaclass=abc.ABCMeta):
                 # unhashable list
                 return tuple(_serialize(subobj) for subobj in obj)
             elif isinstance(obj, Mapping):
-                return dict((_serialize(key), _serialize(value))
-                            for key, value in obj.items())
+                return {_serialize(key): _serialize(value)
+                        for key, value in obj.items()}
             else:
                 return obj
 

--- a/src/josepy/json_util.py
+++ b/src/josepy/json_util.py
@@ -68,10 +68,12 @@ class Field(object):
         return self._empty(value) and self.omitempty
 
     def _update_params(self, **kwargs):
-        current = dict(json_name=self.json_name, default=self.default,
-                       omitempty=self.omitempty,
-                       decoder=self.fdec, encoder=self.fenc)
-        current.update(kwargs)
+        current = {
+            "json_name": self.json_name, "default": self.default,
+            "omitempty": self.omitempty,
+            "decoder": self.fdec, "encoder": self.fenc,
+            **kwargs,
+        }
         return type(self)(**current)  # pylint: disable=star-args
 
     def decoder(self, fdec):
@@ -104,8 +106,8 @@ class Field(object):
             return tuple(cls.default_decoder(subvalue) for subvalue in value)
         elif isinstance(value, dict):
             return util.frozendict(
-                dict((cls.default_decoder(key), cls.default_decoder(value))
-                     for key, value in value.items()))
+                {cls.default_decoder(key): cls.default_decoder(value)
+                 for key, value in value.items()})
         else:  # integer or string
             return value
 
@@ -210,13 +212,14 @@ class JSONObjectWithFields(util.ImmutableMap,
     @classmethod
     def _defaults(cls):
         """Get default fields values."""
-        return dict([(slot, field.default) for slot, field
-                     in cls._fields.items()])
+        return {
+            slot: field.default for slot, field in cls._fields.items()
+        }
 
     def __init__(self, **kwargs):
         # pylint: disable=star-args
         super(JSONObjectWithFields, self).__init__(
-            **(dict(self._defaults(), **kwargs)))
+            **{**self._defaults(), **kwargs})
 
     def encode(self, name):
         """Encode a single field.

--- a/src/josepy/jwk.py
+++ b/src/josepy/jwk.py
@@ -47,8 +47,8 @@ class JWK(json_util.TypedJSONObjectWithFields):
         """
         digest = hashes.Hash(hash_function(), backend=default_backend())
         digest.update(json.dumps(
-            dict((k, v) for k, v in self.to_json().items()
-                 if k in self.required),
+            {k: v for k, v in self.to_json().items()
+                if k in self.required},
             **self._thumbprint_json_dumps_params).encode())
         return digest.finalize()
 
@@ -245,8 +245,8 @@ class JWKRSA(JWK):
                 'dq': private.dmq1,
                 'qi': private.iqmp,
             }
-        return dict((key, self._encode_param(value))
-                    for key, value in params.items())
+        return {key: self._encode_param(value)
+                for key, value in params.items()}
 
 
 @JWK.register

--- a/src/josepy/jws.py
+++ b/src/josepy/jws.py
@@ -74,9 +74,9 @@ class Header(json_util.JSONObjectWithFields):
 
     def not_omitted(self):
         """Fields that would not be omitted in the JSON object."""
-        return dict((name, getattr(self, name))
-                    for name, field in self._fields.items()
-                    if not field.omit(getattr(self, name)))
+        return {name: getattr(self, name)
+                for name, field in self._fields.items()
+                if not field.omit(getattr(self, name))}
 
     def __add__(self, other):
         if not isinstance(other, type(self)):

--- a/src/josepy/util.py
+++ b/src/josepy/util.py
@@ -182,8 +182,7 @@ class ImmutableMap(Mapping, Hashable):  # type: ignore
 
     def update(self, **kwargs):
         """Return updated map."""
-        items = dict(self)
-        items.update(kwargs)
+        items = {**self, **kwargs}
         return type(self)(**items)  # pylint: disable=star-args
 
     def __getitem__(self, key):


### PR DESCRIPTION
This include dict comprehension, `{**a, **b}` dict merging, and using only literals (`{}` instead of `dict`)