### PR TITLE
Update constraints and pin mypy

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -16,6 +16,7 @@ distlib==0.3.2
 execnet==1.8.1
 filelock==3.0.12
 flake8==3.9.2
+importlib-metadata==4.4.0
 iniconfig==1.1.1
 mccabe==0.6.1
 mypy==0.812
@@ -38,3 +39,4 @@ tox==3.23.1
 typed-ast==1.4.3
 typing-extensions==3.10.0.0
 virtualenv==20.4.7
+zipp==3.4.1

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,45 +1,40 @@
 # Specifies Python package versions for testing.
 # To update:
 # python3 -m venv venv && source venv/bin/activate
-# python3 -m pip install -e .[dev,tests] && pip freeze
+# python3 -m pip install -e '.[dev,tests]' && pip freeze
 # Examine the produced list and update invididual entries here.
 # If anything changes about this file's contents or location, we may
 # need to submit a PR to pyca/cryptography, since they rely on it.
 
 apipkg==1.5
-atomicwrites==1.4.0
-attrs==19.3.0
-cffi==1.14.0
-configparser==4.0.2
-contextlib2==0.6.0.post1
-coverage==5.1
-cryptography==2.9.2
-entrypoints==0.3
-enum34==1.1.10
-execnet==1.7.1
-flake8==3.7.9
-funcsigs==1.0.2
-functools32==3.2.3.post2
-importlib-metadata==1.6.0
-ipaddress==1.0.23
+appdirs==1.4.4
+attrs==21.2.0
+cffi==1.14.5
+coverage==5.5
+cryptography==3.4.7
+distlib==0.3.2
+execnet==1.8.1
+filelock==3.0.12
+flake8==3.9.2
+iniconfig==1.1.1
 mccabe==0.6.1
-more-itertools==5.0.0
-packaging==20.3
-pathlib2==2.3.5
-pbr==5.4.5
+mypy==0.812
+mypy-extensions==0.4.3
+packaging==20.9
 pluggy==0.13.1
-py==1.8.1
-pycodestyle==2.5.0
+py==1.10.0
+pycodestyle==2.7.0
 pycparser==2.20
-pyflakes==2.1.1
-pyOpenSSL==19.1.0
+pyflakes==2.3.1
+pyOpenSSL==20.0.1
 pyparsing==2.4.7
-pytest==4.6.10
+pytest==6.2.4
 pytest-cache==1.0
-pytest-cov==2.8.1
-pytest-flake8==1.0.5
-scandir==1.10.0
-six==1.14.0
-typing==3.7.4.1
-wcwidth==0.1.9
-zipp==1.2.0
+pytest-cov==2.12.1
+pytest-flake8==1.0.7
+six==1.16.0
+toml==0.10.2
+tox==3.23.1
+typed-ast==1.4.3
+typing-extensions==3.10.0.0
+virtualenv==20.4.7

--- a/setup.py
+++ b/setup.py
@@ -18,15 +18,15 @@ install_requires = [
 
 testing_requires = [
     'coverage>=4.0',
+    'flake8',
+    'mypy',
     'pytest-cache>=1.0',
     'pytest-cov',
-    'flake8',
     'pytest-flake8>=0.5',
     'pytest>=2.8.0',
 ]
 
 dev_extras = [
-    'mypy',
     'pytest',
     'tox',
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -15,5 +15,3 @@ ignore = W504, E501
 [testenv:mypy]
 commands =
     mypy src/josepy
-deps =
-    -e .[dev]


### PR DESCRIPTION
These constraints hadn't been updated since we added mypy to our dev or tests extras so mypy wasn't pinned and a new release came out yesterday causing our tests to fail. This PR adds mypy to constraints and pins it to the previously working version for now.

Additionally, the constraints file wasn't being used in the tox config for mypy. To fix this, I moved mypy to the test extras and deleted the mypy deps setting in the tox config so it is inherited from the default testenv which uses the constraints file.

I also added quotes around .[dev,tests] because without it zsh complains:
```
$ python3 -m pip install -e .[dev,tests] && pip freeze
zsh: no matches found: .[dev,tests]
```