### PR TITLE
Remove pytest-cache dep

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 1.9.0 (master)
 --------------
 
+* Removed pytest-cache testing dependency.
+
 1.8.0 (2021-03-15)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ testing_requires = [
     'coverage>=4.0',
     'flake8',
     'mypy',
-    'pytest-cache>=1.0',
     'pytest-cov',
     'pytest-flake8>=0.5',
     'pytest>=2.8.0',


### PR DESCRIPTION
Fixes https://github.com/certbot/josepy/issues/102.

As seen at https://docs.pytest.org/en/stable/changelog.html#id1406, `pytest` added `pytest-cache` functionality in the version 2.8 which is what we specify as our minimum pytest version.