### PR TITLE
Use set literal in JWSTest.test_compact_lost_unprotected

### DIFF
--- a/src/josepy/jws_test.py
+++ b/src/josepy/jws_test.py
@@ -135,8 +135,7 @@ class JWSTest(unittest.TestCase):
         mixed = JWS.from_compact(compact)
 
         self.assertNotEqual(self.mixed, mixed)
-        self.assertEqual(
-            set(['alg']), set(mixed.signature.combined.not_omitted()))
+        self.assertEqual({'alg'}, set(mixed.signature.combined.not_omitted()))
 
     def test_from_compact_missing_components(self):
         from josepy.jws import JWS


### PR DESCRIPTION
Quite a bit faster, and more Pythonic. I used https://pypi.org/project/flake8-comprehensions/ and this was the only one; it probably should have been included when I did #96 

```
❯ ipython3
Python 3.6.9 (default, Oct  8 2020, 12:12:24) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.16.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: %timeit set(['alg'])
125 ns ± 0.85 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)

In [2]: %timeit {'alg'}
42.4 ns ± 0.308 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)
```