### PR TITLE
Add types to functions (out of tests modules) in josepy

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,4 +1,4 @@
-name: Python Tests for Joespy
+name: Python Tests for Josepy
 
 on:
   pull_request:
@@ -17,9 +17,9 @@ jobs:
     env:
       TOXENV: mypy
     strategy:
+      fail-fast: false
       matrix:
         python: [3.6, 3.7, 3.8, 3.9]
-
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python
@@ -42,8 +42,7 @@ jobs:
         run: tox -e py
       # STATIC CHECK
       - name: Run mypy
-        run: |
-         mypy src
+        run: mypy src
       # COVERAGE
       - name: Convert Coverage
         run: python -m coverage xml
@@ -52,8 +51,7 @@ jobs:
         with:
           fail_ci_if_error: true
   notify:
-    # Only notify about failed builds and do not notify about failed builds for
-    # PRs.
+    # Only notify about failed builds for branches (not PRs).
     if: ${{ failure() && github.event_name != 'pull_request' }}
     needs: build
     runs-on: ubuntu-20.04

--- a/.gitignore
+++ b/.gitignore
@@ -62,5 +62,8 @@ docs/_build/
 # PyBuilder
 target/
 
-#Ipython Notebook
+# Ipython Notebook
 .ipynb_checkpoints
+
+# Pycharm
+.idea

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,2 +1,4 @@
 [mypy]
 ignore_missing_imports = True
+warn_unused_ignores = True
+show_error_codes = True

--- a/src/josepy/b64.py
+++ b/src/josepy/b64.py
@@ -13,7 +13,7 @@
 import base64
 
 
-def b64encode(data):
+def b64encode(data: bytes) -> bytes:
     """JOSE Base64 encode.
 
     :param data: Data to be encoded.
@@ -30,7 +30,7 @@ def b64encode(data):
     return base64.urlsafe_b64encode(data).rstrip(b'=')
 
 
-def b64decode(data):
+def b64decode(data: bytes) -> bytes:
     """JOSE Base64 decode.
 
     :param data: Base64 string to be decoded. If it's unicode, then

--- a/src/josepy/errors.py
+++ b/src/josepy/errors.py
@@ -1,4 +1,5 @@
 """JOSE errors."""
+from typing import Any
 
 
 class Error(Exception):
@@ -8,7 +9,7 @@ class Error(Exception):
 class DeserializationError(Error):
     """JSON deserialization error."""
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "Deserialization error: {0}".format(
             super().__str__())
 
@@ -25,11 +26,11 @@ class UnrecognizedTypeError(DeserializationError):
 
     """
 
-    def __init__(self, typ, jobj):
+    def __init__(self, typ: str, jobj: Any) -> None:
         self.typ = typ
         self.jobj = jobj
         super().__init__(str(self))
 
-    def __str__(self):
+    def __str__(self) -> str:
         return '{0} was not recognized, full message: {1}'.format(
             self.typ, self.jobj)

--- a/src/josepy/interfaces.py
+++ b/src/josepy/interfaces.py
@@ -1,9 +1,9 @@
 """JOSE interfaces."""
 import abc
 import json
+from typing import Any
 
-
-from josepy import errors, util
+from josepy import errors
 
 from collections.abc import Sequence, Mapping
 
@@ -100,7 +100,7 @@ class JSONDeSerializable(object, metaclass=abc.ABCMeta):
     """
 
     @abc.abstractmethod
-    def to_partial_json(self):  # pragma: no cover
+    def to_partial_json(self) -> Any:  # pragma: no cover
         """Partially serialize.
 
         Following the example, **partial serialization** means the following::
@@ -118,7 +118,7 @@ class JSONDeSerializable(object, metaclass=abc.ABCMeta):
         """
         raise NotImplementedError()
 
-    def to_json(self):
+    def to_json(self) -> Any:
         """Fully serialize.
 
         Again, following the example from before, **full serialization**
@@ -150,8 +150,9 @@ class JSONDeSerializable(object, metaclass=abc.ABCMeta):
 
         return _serialize(self)
 
-    @util.abstractclassmethod
-    def from_json(cls, jobj):  # pylint: disable=unused-argument
+    @classmethod
+    @abc.abstractmethod
+    def from_json(cls, jobj: Any) -> 'JSONDeSerializable':
         """Deserialize a decoded JSON document.
 
         :param jobj: Python object, composed of only other basic data
@@ -169,7 +170,7 @@ class JSONDeSerializable(object, metaclass=abc.ABCMeta):
         return cls()  # pylint: disable=abstract-class-instantiated
 
     @classmethod
-    def json_loads(cls, json_string):
+    def json_loads(cls, json_string: str) -> 'JSONDeSerializable':
         """Deserialize from JSON document string."""
         try:
             loads = json.loads(json_string)
@@ -177,7 +178,7 @@ class JSONDeSerializable(object, metaclass=abc.ABCMeta):
             raise errors.DeserializationError(error)
         return cls.from_json(loads)
 
-    def json_dumps(self, **kwargs):
+    def json_dumps(self, **kwargs: Any) -> str:
         """Dump to JSON string using proper serializer.
 
         :returns: JSON document string.
@@ -186,7 +187,7 @@ class JSONDeSerializable(object, metaclass=abc.ABCMeta):
         """
         return json.dumps(self, default=self.json_dump_default, **kwargs)
 
-    def json_dumps_pretty(self):
+    def json_dumps_pretty(self) -> str:
         """Dump the object to pretty JSON document string.
 
         :rtype: str
@@ -195,7 +196,7 @@ class JSONDeSerializable(object, metaclass=abc.ABCMeta):
         return self.json_dumps(sort_keys=True, indent=4, separators=(',', ': '))
 
     @classmethod
-    def json_dump_default(cls, python_object):
+    def json_dump_default(cls, python_object: 'JSONDeSerializable') -> Any:
         """Serialize Python object.
 
         This function is meant to be passed as ``default`` to

--- a/src/josepy/json_util.py
+++ b/src/josepy/json_util.py
@@ -9,9 +9,10 @@ The framework presented here is somewhat based on `Go's "json" package`_
 import abc
 import binascii
 import logging
-from typing import Dict, Type
+from typing import Dict, Type, Any, Callable, List, Mapping, Optional
 
-import OpenSSL
+from OpenSSL import crypto
+import josepy.util
 
 from josepy import b64, errors, interfaces, util
 
@@ -44,8 +45,9 @@ class Field:
     """
     __slots__ = ('json_name', 'default', 'omitempty', 'fdec', 'fenc')
 
-    def __init__(self, json_name, default=None, omitempty=False,
-                 decoder=None, encoder=None):
+    def __init__(self, json_name: str, default: Any = None, omitempty: bool = False,
+                 decoder: Callable[[Any], Any] = None,
+                 encoder: Callable[[Any], Any] = None) -> None:
         # pylint: disable=too-many-arguments
         self.json_name = json_name
         self.default = default
@@ -55,7 +57,7 @@ class Field:
         self.fenc = self.default_encoder if encoder is None else encoder
 
     @classmethod
-    def _empty(cls, value):
+    def _empty(cls, value: Any) -> bool:
         """Is the provided value considered "empty" for this field?
 
         This is useful for subclasses that might want to override the
@@ -64,37 +66,39 @@ class Field:
         """
         return not isinstance(value, bool) and not value
 
-    def omit(self, value):
+    def omit(self, value: Any) -> bool:
         """Omit the value in output?"""
         return self._empty(value) and self.omitempty
 
-    def _update_params(self, **kwargs):
+    def _update_params(self, **kwargs: Any) -> 'Field':
         current = {
-            "json_name": self.json_name, "default": self.default,
+            "json_name": self.json_name,
+            "default": self.default,
             "omitempty": self.omitempty,
-            "decoder": self.fdec, "encoder": self.fenc,
+            "decoder": self.fdec,
+            "encoder": self.fenc,
             **kwargs,
         }
-        return type(self)(**current)  # pylint: disable=star-args
+        return type(self)(**current)  # type: ignore[arg-type]  # pylint: disable=star-args
 
-    def decoder(self, fdec):
+    def decoder(self, fdec: Callable[[Any], Any]) -> 'Field':
         """Descriptor to change the decoder on JSON object field."""
         return self._update_params(decoder=fdec)
 
-    def encoder(self, fenc):
+    def encoder(self, fenc: Callable[[Any], Any]) -> 'Field':
         """Descriptor to change the encoder on JSON object field."""
         return self._update_params(encoder=fenc)
 
-    def decode(self, value):
+    def decode(self, value: Any) -> Any:
         """Decode a value, optionally with context JSON object."""
         return self.fdec(value)
 
-    def encode(self, value):
+    def encode(self, value: Any) -> Any:
         """Encode a value, optionally with context JSON object."""
         return self.fenc(value)
 
     @classmethod
-    def default_decoder(cls, value):
+    def default_decoder(cls, value: Any) -> Any:
         """Default decoder.
 
         Recursively deserialize into immutable types (
@@ -113,7 +117,7 @@ class Field:
             return value
 
     @classmethod
-    def default_encoder(cls, value):
+    def default_encoder(cls, value: Any) -> Any:
         """Default (passthrough) encoder."""
         # field.to_partial_json() is no good as encoder has to do partial
         # serialization only
@@ -162,7 +166,8 @@ class JSONObjectWithFieldsMeta(abc.ABCMeta):
 
     _fields: Dict[str, Field] = {}
 
-    def __new__(mcs, name, bases, dikt):
+    def __new__(mcs, name: str, bases: List[str],
+                dikt: Dict[str, Any]) -> 'JSONObjectWithFieldsMeta':
         fields = {}
 
         for base in bases:
@@ -179,7 +184,7 @@ class JSONObjectWithFieldsMeta(abc.ABCMeta):
             list(dikt['_orig_slots']) + list(fields.keys()))
         dikt['_fields'] = fields
 
-        return abc.ABCMeta.__new__(mcs, name, bases, dikt)
+        return abc.ABCMeta.__new__(mcs, name, bases, dikt)  # type: ignore[call-overload]
 
 
 class JSONObjectWithFields(util.ImmutableMap,
@@ -211,20 +216,19 @@ class JSONObjectWithFields(util.ImmutableMap,
       assert Foo(bar='baz').bar == 'baz'
 
     """
-
     @classmethod
-    def _defaults(cls) -> Dict:
+    def _defaults(cls) -> Dict[str, Any]:
         """Get default fields values."""
         return {
             slot: field.default for slot, field in cls._fields.items()
         }
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: Any) -> None:
         # pylint: disable=star-args
         super().__init__(
             **{**self._defaults(), **kwargs})
 
-    def encode(self, name):
+    def encode(self, name: str) -> Any:
         """Encode a single field.
 
         :param str name: Name of the field to be encoded.
@@ -234,17 +238,17 @@ class JSONObjectWithFields(util.ImmutableMap,
 
         """
         try:
-            field = self._fields[name]
+            field = self._fields[name]  # type: ignore[attr-defined]
         except KeyError:
             raise errors.Error("Field not found: {0}".format(name))
 
         return field.encode(getattr(self, name))
 
-    def fields_to_partial_json(self):
+    def fields_to_partial_json(self) -> Dict[str, Any]:
         """Serialize fields to JSON."""
         jobj = {}
         omitted = set()
-        for slot, field in self._fields.items():
+        for slot, field in self._fields.items():  # type: ignore[attr-defined]
             value = getattr(self, slot)
 
             if field.omit(value):
@@ -258,11 +262,11 @@ class JSONObjectWithFields(util.ImmutableMap,
                             slot, value, error))
         return jobj
 
-    def to_partial_json(self):
+    def to_partial_json(self) -> Dict[str, Any]:
         return self.fields_to_partial_json()
 
     @classmethod
-    def _check_required(cls, jobj):
+    def _check_required(cls, jobj: Mapping[str, Any]) -> None:
         missing = set()
         for _, field in cls._fields.items():
             if not field.omitempty and field.json_name not in jobj:
@@ -274,7 +278,7 @@ class JSONObjectWithFields(util.ImmutableMap,
                     ','.join(missing)))
 
     @classmethod
-    def fields_from_json(cls, jobj):
+    def fields_from_json(cls, jobj: Mapping[str, Any]) -> Any:
         """Deserialize fields from JSON."""
         cls._check_required(jobj)
         fields = {}
@@ -292,7 +296,7 @@ class JSONObjectWithFields(util.ImmutableMap,
         return fields
 
     @classmethod
-    def from_json(cls, jobj):
+    def from_json(cls, jobj: Dict[str, Any]) -> 'JSONObjectWithFields':
         return cls(**cls.fields_from_json(jobj))
 
 
@@ -307,7 +311,7 @@ def encode_b64jose(data: bytes) -> str:
     return b64.b64encode(data).decode('ascii')
 
 
-def decode_b64jose(data, size=None, minimum=False):
+def decode_b64jose(data: str, size: Optional[int] = None, minimum: Optional[bool] = False) -> bytes:
     """Decode JOSE Base-64 field.
 
     :param unicode data:
@@ -331,7 +335,7 @@ def decode_b64jose(data, size=None, minimum=False):
     return decoded
 
 
-def encode_hex16(value):
+def encode_hex16(value: bytes) -> str:
     """Hexlify.
 
     :param bytes value:
@@ -341,7 +345,7 @@ def encode_hex16(value):
     return binascii.hexlify(value).decode()
 
 
-def decode_hex16(value, size=None, minimum=False):
+def decode_hex16(value: str, size: Optional[int] = None, minimum: Optional[bool] = False) -> bytes:
     """Decode hexlified field.
 
     :param unicode value:
@@ -352,28 +356,31 @@ def decode_hex16(value, size=None, minimum=False):
     :rtype: bytes
 
     """
-    value = value.encode()
-    if size is not None and ((not minimum and len(value) != size * 2) or
-                             (minimum and len(value) < size * 2)):
+    value_b = value.encode()
+    if size is not None and ((not minimum and len(value_b) != size * 2) or
+                             (minimum and len(value_b) < size * 2)):
         raise errors.DeserializationError()
     try:
-        return binascii.unhexlify(value)
+        return binascii.unhexlify(value_b)
     except binascii.Error as error:
         raise errors.DeserializationError(error)
 
 
-def encode_cert(cert):
+def encode_cert(cert: josepy.util.ComparableX509) -> str:
     """Encode certificate as JOSE Base-64 DER.
 
     :type cert: `OpenSSL.crypto.X509` wrapped in `.ComparableX509`
     :rtype: unicode
 
     """
-    return encode_b64jose(OpenSSL.crypto.dump_certificate(
-        OpenSSL.crypto.FILETYPE_ASN1, cert.wrapped))
+    if isinstance(cert.wrapped, crypto.X509Req):
+        raise ValueError("Error input is actually a certificate request.")
+
+    return encode_b64jose(crypto.dump_certificate(
+        crypto.FILETYPE_ASN1, cert.wrapped))
 
 
-def decode_cert(b64der):
+def decode_cert(b64der: str) -> josepy.util.ComparableX509:
     """Decode JOSE Base-64 DER-encoded certificate.
 
     :param unicode b64der:
@@ -381,24 +388,27 @@ def decode_cert(b64der):
 
     """
     try:
-        return util.ComparableX509(OpenSSL.crypto.load_certificate(
-            OpenSSL.crypto.FILETYPE_ASN1, decode_b64jose(b64der)))
-    except OpenSSL.crypto.Error as error:
+        return util.ComparableX509(crypto.load_certificate(
+            crypto.FILETYPE_ASN1, decode_b64jose(b64der)))
+    except crypto.Error as error:
         raise errors.DeserializationError(error)
 
 
-def encode_csr(csr):
+def encode_csr(csr: josepy.util.ComparableX509) -> str:
     """Encode CSR as JOSE Base-64 DER.
 
     :type csr: `OpenSSL.crypto.X509Req` wrapped in `.ComparableX509`
     :rtype: unicode
 
     """
-    return encode_b64jose(OpenSSL.crypto.dump_certificate_request(
-        OpenSSL.crypto.FILETYPE_ASN1, csr.wrapped))
+    if isinstance(csr.wrapped, crypto.X509):
+        raise ValueError("Error input is actually a certificate.")
+
+    return encode_b64jose(crypto.dump_certificate_request(
+        crypto.FILETYPE_ASN1, csr.wrapped))
 
 
-def decode_csr(b64der):
+def decode_csr(b64der: str) -> josepy.util.ComparableX509:
     """Decode JOSE Base-64 DER-encoded CSR.
 
     :param unicode b64der:
@@ -406,9 +416,9 @@ def decode_csr(b64der):
 
     """
     try:
-        return util.ComparableX509(OpenSSL.crypto.load_certificate_request(
-            OpenSSL.crypto.FILETYPE_ASN1, decode_b64jose(b64der)))
-    except OpenSSL.crypto.Error as error:
+        return util.ComparableX509(crypto.load_certificate_request(
+            crypto.FILETYPE_ASN1, decode_b64jose(b64der)))
+    except crypto.Error as error:
         raise errors.DeserializationError(error)
 
 
@@ -429,14 +439,15 @@ class TypedJSONObjectWithFields(JSONObjectWithFields):
     """Types registered for JSON deserialization"""
 
     @classmethod
-    def register(cls, type_cls, typ=None):
+    def register(cls, type_cls: Type['TypedJSONObjectWithFields'],
+                 typ: Optional[str] = None) -> Type['TypedJSONObjectWithFields']:
         """Register class for JSON deserialization."""
         typ = type_cls.typ if typ is None else typ
         cls.TYPES[typ] = type_cls
         return type_cls
 
     @classmethod
-    def get_type_cls(cls, jobj):
+    def get_type_cls(cls, jobj: Mapping[str, Any]) -> Type['TypedJSONObjectWithFields']:
         """Get the registered class for ``jobj``."""
         if cls in cls.TYPES.values():
             if cls.type_field_name not in jobj:
@@ -460,7 +471,7 @@ class TypedJSONObjectWithFields(JSONObjectWithFields):
         except KeyError:
             raise errors.UnrecognizedTypeError(typ, jobj)
 
-    def to_partial_json(self):
+    def to_partial_json(self) -> Dict[str, Any]:
         """Get JSON serializable object.
 
         :returns: Serializable JSON object representing ACME typed object.
@@ -474,7 +485,7 @@ class TypedJSONObjectWithFields(JSONObjectWithFields):
         return jobj
 
     @classmethod
-    def from_json(cls, jobj):
+    def from_json(cls, jobj: Mapping[str, Any]) -> 'TypedJSONObjectWithFields':
         """Deserialize ACME object from valid JSON object.
 
         :raises josepy.errors.UnrecognizedTypeError: if type

--- a/src/josepy/json_util.py
+++ b/src/josepy/json_util.py
@@ -311,7 +311,7 @@ def encode_b64jose(data: bytes) -> str:
     return b64.b64encode(data).decode('ascii')
 
 
-def decode_b64jose(data: str, size: Optional[int] = None, minimum: Optional[bool] = False) -> bytes:
+def decode_b64jose(data: str, size: Optional[int] = None, minimum: bool = False) -> bytes:
     """Decode JOSE Base-64 field.
 
     :param unicode data:

--- a/src/josepy/json_util.py
+++ b/src/josepy/json_util.py
@@ -345,7 +345,7 @@ def encode_hex16(value: bytes) -> str:
     return binascii.hexlify(value).decode()
 
 
-def decode_hex16(value: str, size: Optional[int] = None, minimum: Optional[bool] = False) -> bytes:
+def decode_hex16(value: str, size: Optional[int] = None, minimum: bool = False) -> bytes:
     """Decode hexlified field.
 
     :param unicode value:

--- a/src/josepy/jwa.py
+++ b/src/josepy/jwa.py
@@ -109,7 +109,7 @@ class _JWARSA:
         try:
             if new_api:
                 return key.sign(msg, self.padding, self.hash)
-            signer = key.signer(self.padding, self.hash)  # type: ignore[attr-defined]
+            signer = key.signer(self.padding, self.hash)
         except AttributeError as error:
             logger.debug(error, exc_info=True)
             raise errors.Error("Public key cannot be used for signing")
@@ -181,7 +181,7 @@ class _JWAEC(JWASignature):
         try:
             if new_api:
                 return key.sign(msg, ec.ECDSA(self.hash))
-            signer = key.signer(ec.ECDSA(self.hash))  # type: ignore[attr-defined]
+            signer = key.signer(ec.ECDSA(self.hash))
         except AttributeError as error:
             logger.debug(error, exc_info=True)
             raise errors.Error('Public key cannot be used for signing')

--- a/src/josepy/jwa.py
+++ b/src/josepy/jwa.py
@@ -5,15 +5,16 @@ https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40
 """
 import abc
 import logging
-from typing import Dict, Type
+from typing import Dict, Any, Callable
 
 import cryptography.exceptions
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import hmac
-from cryptography.hazmat.primitives.asymmetric import padding, ec
+from cryptography.hazmat.primitives.asymmetric import padding, ec, rsa
 from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
 from cryptography.hazmat.primitives.asymmetric.utils import encode_dss_signature
+from cryptography.hazmat.primitives.hashes import HashAlgorithm
 
 from josepy import errors, interfaces, jwk
 
@@ -31,59 +32,60 @@ class JWA(interfaces.JSONDeSerializable):  # pylint: disable=abstract-method
 
 class JWASignature(JWA, Hashable):
     """Base class for JSON Web Signature Algorithms."""
-    SIGNATURES: Dict[str, Type] = {}
+    SIGNATURES: Dict[str, 'JWASignature'] = {}
+    kty: Any
 
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         self.name = name
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         if not isinstance(other, JWASignature):
             return NotImplemented
         return self.name == other.name
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash((self.__class__, self.name))
 
     @classmethod
-    def register(cls, signature_cls):
+    def register(cls, signature_cls: 'JWASignature') -> 'JWASignature':
         """Register class for JSON deserialization."""
         cls.SIGNATURES[signature_cls.name] = signature_cls
         return signature_cls
 
-    def to_partial_json(self):
+    def to_partial_json(self) -> Any:
         return self.name
 
     @classmethod
-    def from_json(cls, jobj):
+    def from_json(cls, jobj: Any) -> 'JWASignature':
         return cls.SIGNATURES[jobj]
 
     @abc.abstractmethod
-    def sign(self, key, msg):  # pragma: no cover
+    def sign(self, key: Any, msg: bytes) -> bytes:  # pragma: no cover
         """Sign the ``msg`` using ``key``."""
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def verify(self, key, msg, sig):  # pragma: no cover
+    def verify(self, key: Any, msg: bytes, sig: bytes) -> bool:  # pragma: no cover
         """Verify the ``msg`` and ``sig`` using ``key``."""
         raise NotImplementedError()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.name
 
 
 class _JWAHS(JWASignature):
     kty = jwk.JWKOct
 
-    def __init__(self, name, hash_):
+    def __init__(self, name: str, hash_: Callable[[], HashAlgorithm]):
         super().__init__(name)
         self.hash = hash_()
 
-    def sign(self, key, msg):
+    def sign(self, key: bytes, msg: bytes) -> bytes:
         signer = hmac.HMAC(key, self.hash, backend=default_backend())
         signer.update(msg)
         return signer.finalize()
 
-    def verify(self, key, msg, sig):
+    def verify(self, key: bytes, msg: bytes, sig: bytes) -> bool:
         verifier = hmac.HMAC(key, self.hash, backend=default_backend())
         verifier.update(msg)
         try:
@@ -97,10 +99,10 @@ class _JWAHS(JWASignature):
 
 class _JWARSA:
     kty = jwk.JWKRSA
-    padding = NotImplemented
-    hash = NotImplemented
+    padding: Any = NotImplemented
+    hash: HashAlgorithm = NotImplemented
 
-    def sign(self, key, msg):
+    def sign(self, key: rsa.RSAPrivateKey, msg: bytes) -> bytes:
         """Sign the ``msg`` using ``key``."""
         # If cryptography library supports new style api (v1.4 and later)
         new_api = hasattr(key, "sign")
@@ -121,7 +123,7 @@ class _JWARSA:
             logger.debug(error, exc_info=True)
             raise errors.Error(str(error))
 
-    def verify(self, key, msg, sig):
+    def verify(self, key: rsa.RSAPublicKey, msg: bytes, sig: bytes) -> bool:
         """Verify the ``msg` and ``sig`` using ``key``."""
         # If cryptography library supports new style api (v1.4 and later)
         new_api = hasattr(key, "verify")
@@ -142,7 +144,7 @@ class _JWARSA:
 
 class _JWARS(_JWARSA, JWASignature):
 
-    def __init__(self, name, hash_):
+    def __init__(self, name: str, hash_: Callable[[], HashAlgorithm]) -> None:
         super().__init__(name)
         self.padding = padding.PKCS1v15()
         self.hash = hash_()
@@ -150,7 +152,7 @@ class _JWARS(_JWARSA, JWASignature):
 
 class _JWAPS(_JWARSA, JWASignature):
 
-    def __init__(self, name, hash_):
+    def __init__(self, name: str, hash_: Callable[[], HashAlgorithm]) -> None:
         super().__init__(name)
         self.padding = padding.PSS(
             mgf=padding.MGF1(hash_()),
@@ -161,11 +163,11 @@ class _JWAPS(_JWARSA, JWASignature):
 class _JWAEC(JWASignature):
     kty = jwk.JWKEC
 
-    def __init__(self, name, hash_):
+    def __init__(self, name: str, hash_: Callable[[], HashAlgorithm]):
         super().__init__(name)
         self.hash = hash_()
 
-    def sign(self, key, msg):
+    def sign(self, key: ec.EllipticCurvePrivateKey, msg: bytes) -> bytes:
         """Sign the ``msg`` using ``key``."""
         sig = self._sign(key, msg)
         dr, ds = decode_dss_signature(sig)
@@ -173,7 +175,7 @@ class _JWAEC(JWASignature):
         return (dr.to_bytes(length=length, byteorder='big') +
                 ds.to_bytes(length=length, byteorder='big'))
 
-    def _sign(self, key, msg):
+    def _sign(self, key: ec.EllipticCurvePrivateKey, msg: bytes) -> bytes:
         # If cryptography library supports new style api (v1.4 and later)
         new_api = hasattr(key, 'sign')
         try:
@@ -193,7 +195,7 @@ class _JWAEC(JWASignature):
             logger.debug(error, exc_info=True)
             raise errors.Error(str(error))
 
-    def verify(self, key, msg, sig):
+    def verify(self, key: ec.EllipticCurvePublicKey, msg: bytes, sig: bytes) -> bool:
         """Verify the ``msg` and ``sig`` using ``key``."""
         rlen = jwk.JWKEC.expected_length_for_curve(key.curve)
         if len(sig) != 2 * rlen:
@@ -205,7 +207,7 @@ class _JWAEC(JWASignature):
         )
         return self._verify(key, msg, asn1sig)
 
-    def _verify(self, key, msg, asn1sig):
+    def _verify(self, key: ec.EllipticCurvePublicKey, msg: bytes, asn1sig: bytes) -> bool:
         # If cryptography library supports new style api (v1.4 and later)
         new_api = hasattr(key, 'verify')
         if not new_api:

--- a/src/josepy/jwk.py
+++ b/src/josepy/jwk.py
@@ -73,22 +73,22 @@ class JWK(json_util.TypedJSONObjectWithFields, metaclass=abc.ABCMeta):
         exceptions = {}
 
         # private key?
-        for loader in (serialization.load_pem_private_key,
-                       serialization.load_der_private_key):
+        for loader_private in (serialization.load_pem_private_key,
+                               serialization.load_der_private_key):
             try:
-                return loader(data, password, backend)  # type: ignore[operator]
+                return loader_private(data, password, backend)
             except (ValueError, TypeError,
                     cryptography.exceptions.UnsupportedAlgorithm) as error:
-                exceptions[str(loader)] = error
+                exceptions[str(loader_private)] = error
 
         # public key?
-        for loader in (serialization.load_pem_public_key,
-                       serialization.load_der_public_key):
+        for loader_public in (serialization.load_pem_public_key,
+                              serialization.load_der_public_key):
             try:
-                return loader(data, backend)  # type: ignore[operator]
+                return loader_public(data, backend)
             except (ValueError,
                     cryptography.exceptions.UnsupportedAlgorithm) as error:
-                exceptions[str(loader)] = error
+                exceptions[str(loader_public)] = error
 
         # no luck
         raise errors.Error('Unable to deserialize key: {0}'.format(exceptions))

--- a/src/josepy/jwk.py
+++ b/src/josepy/jwk.py
@@ -4,9 +4,10 @@ import json
 import logging
 import math
 
-from typing import Dict, Optional, Sequence, Type, Union
+from typing import Dict, Optional, Sequence, Type, Union, Callable, Any, Tuple, Mapping
 
 import cryptography.exceptions
+import josepy.util
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
@@ -22,8 +23,8 @@ class JWK(json_util.TypedJSONObjectWithFields, metaclass=abc.ABCMeta):
     # pylint: disable=too-few-public-methods
     """JSON Web Key."""
     type_field_name = 'kty'
-    TYPES: Dict[str, Type] = {}
-    cryptography_key_types: Sequence[Type] = ()
+    TYPES: Dict[str, Type['JWK']] = {}
+    cryptography_key_types: Tuple[Type[Any], ...] = ()
     """Subclasses should override."""
 
     required: Sequence[str] = NotImplemented
@@ -38,8 +39,10 @@ class JWK(json_util.TypedJSONObjectWithFields, metaclass=abc.ABCMeta):
         # code points of the member names"
         'sort_keys': True,
     }
+    key: Any
 
-    def thumbprint(self, hash_function=hashes.SHA256):
+    def thumbprint(self,
+                   hash_function: Callable[[], hashes.HashAlgorithm] = hashes.SHA256) -> bytes:
         """Compute JWK Thumbprint.
 
         https://tools.ietf.org/html/rfc7638
@@ -51,11 +54,11 @@ class JWK(json_util.TypedJSONObjectWithFields, metaclass=abc.ABCMeta):
         digest.update(json.dumps(
             {k: v for k, v in self.to_json().items()
                 if k in self.required},
-            **self._thumbprint_json_dumps_params).encode())
+            **self._thumbprint_json_dumps_params).encode())  # type: ignore[arg-type]
         return digest.finalize()
 
     @abc.abstractmethod
-    def public_key(self):  # pragma: no cover
+    def public_key(self) -> 'JWK':  # pragma: no cover
         """Generate JWK with public key.
 
         For symmetric cryptosystems, this would return ``self``.
@@ -64,33 +67,35 @@ class JWK(json_util.TypedJSONObjectWithFields, metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
     @classmethod
-    def _load_cryptography_key(cls, data, password=None, backend=None):
+    def _load_cryptography_key(cls, data: bytes, password: Optional[bytes] = None,
+                               backend: Optional[Any] = None) -> Any:
         backend = default_backend() if backend is None else backend
         exceptions = {}
 
         # private key?
-        for loader in (serialization.load_pem_private_key,
-                       serialization.load_der_private_key):
+        for loader_private in (serialization.load_pem_private_key,
+                               serialization.load_der_private_key):
             try:
-                return loader(data, password, backend)
+                return loader_private(data, password, backend)
             except (ValueError, TypeError,
                     cryptography.exceptions.UnsupportedAlgorithm) as error:
-                exceptions[loader] = error
+                exceptions[str(loader_private)] = error
 
         # public key?
-        for loader in (serialization.load_pem_public_key,
-                       serialization.load_der_public_key):
+        for loader_public in (serialization.load_pem_public_key,
+                              serialization.load_der_public_key):
             try:
-                return loader(data, backend)
+                return loader_public(data, backend)
             except (ValueError,
                     cryptography.exceptions.UnsupportedAlgorithm) as error:
-                exceptions[loader] = error
+                exceptions[str(loader_public)] = error
 
         # no luck
         raise errors.Error('Unable to deserialize key: {0}'.format(exceptions))
 
     @classmethod
-    def load(cls, data, password=None, backend=None):
+    def load(cls, data: bytes, password: Optional[bytes] = None,
+             backend: Optional[Any] = None) -> 'JWK':
         """Load serialized key as JWK.
 
         :param str data: Public or private key serialized as PEM or DER.
@@ -111,8 +116,7 @@ class JWK(json_util.TypedJSONObjectWithFields, metaclass=abc.ABCMeta):
             logger.debug('Loading symmetric key, asymmetric failed: %s', error)
             return JWKOct(key=data)
 
-        if cls.typ is not NotImplemented and not isinstance(
-                key, cls.cryptography_key_types):
+        if cls.typ is not NotImplemented and not isinstance(key, cls.cryptography_key_types):
             raise errors.Error('Unable to deserialize {0} into {1}'.format(
                 key.__class__, cls.__class__))
         for jwk_cls in cls.TYPES.values():
@@ -127,8 +131,9 @@ class JWKOct(JWK):
     typ = 'oct'
     __slots__ = ('key',)
     required = ('k', JWK.type_field_name)
+    key: bytes
 
-    def fields_to_partial_json(self):
+    def fields_to_partial_json(self) -> Dict[str, str]:
         # TODO: An "alg" member SHOULD also be present to identify the
         # algorithm intended to be used with the key, unless the
         # application uses another means or convention to determine
@@ -136,10 +141,10 @@ class JWKOct(JWK):
         return {'k': json_util.encode_b64jose(self.key)}
 
     @classmethod
-    def fields_from_json(cls, jobj):
+    def fields_from_json(cls, jobj: Mapping[str, Any]) -> 'JWKOct':
         return cls(key=json_util.decode_b64jose(jobj['k']))
 
-    def public_key(self):
+    def public_key(self) -> 'JWKOct':
         return self
 
 
@@ -156,15 +161,16 @@ class JWKRSA(JWK):
     cryptography_key_types = (rsa.RSAPublicKey, rsa.RSAPrivateKey)
     __slots__ = ('key',)
     required = ('e', JWK.type_field_name, 'n')
+    key: josepy.util.ComparableRSAKey
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         if 'key' in kwargs and not isinstance(
                 kwargs['key'], util.ComparableRSAKey):
             kwargs['key'] = util.ComparableRSAKey(kwargs['key'])
         super().__init__(*args, **kwargs)
 
     @classmethod
-    def _encode_param(cls, data):
+    def _encode_param(cls, data: int) -> str:
         """Encode Base64urlUInt.
         :type data: long
         :rtype: unicode
@@ -174,7 +180,7 @@ class JWKRSA(JWK):
         return json_util.encode_b64jose(data.to_bytes(byteorder="big", length=length))
 
     @classmethod
-    def _decode_param(cls, data):
+    def _decode_param(cls, data: str) -> int:
         """Decode Base64urlUInt."""
         try:
             binary = json_util.decode_b64jose(data)
@@ -184,49 +190,52 @@ class JWKRSA(JWK):
         except ValueError:  # invalid literal for long() with base 16
             raise errors.DeserializationError()
 
-    def public_key(self):
+    def public_key(self) -> 'JWKRSA':
         return type(self)(key=self.key.public_key())
 
     @classmethod
-    def fields_from_json(cls, jobj):
+    def fields_from_json(cls, jobj: Mapping[str, Any]) -> 'JWKRSA':
         # pylint: disable=invalid-name
         n, e = (cls._decode_param(jobj[x]) for x in ('n', 'e'))
         public_numbers = rsa.RSAPublicNumbers(e=e, n=n)
-        if 'd' not in jobj:  # public key
-            key = public_numbers.public_key(default_backend())
-        else:  # private key
-            d = cls._decode_param(jobj['d'])
-            if ('p' in jobj or 'q' in jobj or 'dp' in jobj or
-                    'dq' in jobj or 'qi' in jobj or 'oth' in jobj):
-                # "If the producer includes any of the other private
-                # key parameters, then all of the others MUST be
-                # present, with the exception of "oth", which MUST
-                # only be present when more than two prime factors
-                # were used."
-                p, q, dp, dq, qi, = all_params = tuple(
-                    jobj.get(x) for x in ('p', 'q', 'dp', 'dq', 'qi'))
-                if tuple(param for param in all_params if param is None):
-                    raise errors.Error(
-                        'Some private parameters are missing: {0}'.format(
-                            all_params))
-                p, q, dp, dq, qi = tuple(
-                    cls._decode_param(x) for x in all_params)
 
-                # TODO: check for oth
-            else:
-                # cryptography>=0.8
-                p, q = rsa.rsa_recover_prime_factors(n, e, d)
-                dp = rsa.rsa_crt_dmp1(d, p)
-                dq = rsa.rsa_crt_dmq1(d, q)
-                qi = rsa.rsa_crt_iqmp(p, q)
+        # public key
+        if 'd' not in jobj:
+            return cls(key=public_numbers.public_key(default_backend()))
 
-            key = rsa.RSAPrivateNumbers(
-                p, q, d, dp, dq, qi, public_numbers).private_key(
-                    default_backend())
+        # private key
+        d = cls._decode_param(jobj['d'])
+        if ('p' in jobj or 'q' in jobj or 'dp' in jobj or
+                'dq' in jobj or 'qi' in jobj or 'oth' in jobj):
+            # "If the producer includes any of the other private
+            # key parameters, then all of the others MUST be
+            # present, with the exception of "oth", which MUST
+            # only be present when more than two prime factors
+            # were used."
+            p, q, dp, dq, qi, = all_params = tuple(
+                jobj.get(x) for x in ('p', 'q', 'dp', 'dq', 'qi'))
+            if tuple(param for param in all_params if param is None):
+                raise errors.Error(
+                    'Some private parameters are missing: {0}'.format(
+                        all_params))
+            p, q, dp, dq, qi = tuple(
+                cls._decode_param(str(x)) for x in all_params)
+
+            # TODO: check for oth
+        else:
+            # cryptography>=0.8
+            p, q = rsa.rsa_recover_prime_factors(n, e, d)
+            dp = rsa.rsa_crt_dmp1(d, p)
+            dq = rsa.rsa_crt_dmq1(d, q)
+            qi = rsa.rsa_crt_iqmp(p, q)
+
+        key = rsa.RSAPrivateNumbers(
+            p, q, d, dp, dq, qi, public_numbers).private_key(
+                default_backend())
 
         return cls(key=key)
 
-    def fields_to_partial_json(self):
+    def fields_to_partial_json(self) -> Dict[str, Any]:
         # pylint: disable=protected-access
         if isinstance(self.key._wrapped, rsa.RSAPublicKey):
             numbers = self.key.public_numbers()
@@ -257,7 +266,7 @@ class JWKEC(JWK):
 
     :ivar key: :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePrivateKey`
         or :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKey` wrapped
-        in :class:`~josepy.util.ComparableRSAKey`
+        in :class:`~josepy.util.ComparableECKey`
 
     """
     typ = 'EC'
@@ -265,15 +274,16 @@ class JWKEC(JWK):
     cryptography_key_types = (
         ec.EllipticCurvePublicKey, ec.EllipticCurvePrivateKey)
     required = ('crv', JWK.type_field_name, 'x', 'y')
+    key: josepy.util.ComparableECKey
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         if 'key' in kwargs and not isinstance(
                 kwargs['key'], util.ComparableECKey):
             kwargs['key'] = util.ComparableECKey(kwargs['key'])
         super().__init__(*args, **kwargs)
 
     @classmethod
-    def _encode_param(cls, data, length):
+    def _encode_param(cls, data: int, length: int) -> str:
         """Encode Base64urlUInt.
         :type data: long
         :type key_size: long
@@ -282,7 +292,7 @@ class JWKEC(JWK):
         return json_util.encode_b64jose(data.to_bytes(byteorder="big", length=length))
 
     @classmethod
-    def _decode_param(cls, data, name, valid_length):
+    def _decode_param(cls, data: str, name: str, valid_length: int) -> int:
         """Decode Base64urlUInt."""
         try:
             binary = json_util.decode_b64jose(data)
@@ -297,7 +307,7 @@ class JWKEC(JWK):
             raise errors.DeserializationError()
 
     @classmethod
-    def _curve_name_to_crv(cls, curve_name):
+    def _curve_name_to_crv(cls, curve_name: str) -> str:
         if curve_name == 'secp256r1':
             return 'P-256'
         if curve_name == 'secp384r1':
@@ -307,7 +317,7 @@ class JWKEC(JWK):
         raise errors.SerializationError()
 
     @classmethod
-    def _crv_to_curve(cls, crv):
+    def _crv_to_curve(cls, crv: str) -> ec.EllipticCurve:
         # crv is case-sensitive
         if crv == 'P-256':
             return ec.SECP256R1()
@@ -318,15 +328,16 @@ class JWKEC(JWK):
         raise errors.DeserializationError()
 
     @classmethod
-    def expected_length_for_curve(cls, curve):
+    def expected_length_for_curve(cls, curve: ec.EllipticCurve) -> int:
         if isinstance(curve, ec.SECP256R1):
             return 32
         elif isinstance(curve, ec.SECP384R1):
             return 48
         elif isinstance(curve, ec.SECP521R1):
             return 66
+        raise ValueError(f'Unexpected curve: {curve}')
 
-    def fields_to_partial_json(self):
+    def fields_to_partial_json(self) -> Dict[str, Any]:
         params = {}
         if isinstance(self.key._wrapped, ec.EllipticCurvePublicKey):
             public = self.key.public_numbers()
@@ -344,21 +355,24 @@ class JWKEC(JWK):
         return params
 
     @classmethod
-    def fields_from_json(cls, jobj):
+    def fields_from_json(cls, jobj: Mapping[str, Any]) -> 'JWKEC':
         # pylint: disable=invalid-name
         curve = cls._crv_to_curve(jobj['crv'])
         expected_length = cls.expected_length_for_curve(curve)
         x, y = (cls._decode_param(jobj[n], n, expected_length) for n in ('x', 'y'))
         public_numbers = ec.EllipticCurvePublicNumbers(x=x, y=y, curve=curve)
-        if 'd' not in jobj:  # public key
-            key = public_numbers.public_key(default_backend())
-        else:  # private key
-            d = cls._decode_param(jobj['d'], 'd', expected_length)
-            key = ec.EllipticCurvePrivateNumbers(d, public_numbers).private_key(
-                default_backend())
+
+        # private key
+        if 'd' not in jobj:
+            return cls(key=public_numbers.public_key(default_backend()))
+
+        # private key
+        d = cls._decode_param(jobj['d'], 'd', expected_length)
+        key = ec.EllipticCurvePrivateNumbers(d, public_numbers).private_key(
+            default_backend())
         return cls(key=key)
 
-    def public_key(self):
+    def public_key(self) -> 'JWKEC':
         # Unlike RSAPrivateKey, EllipticCurvePrivateKey does not contain public_key()
         if hasattr(self.key, 'public_key'):
             key = self.key.public_key()

--- a/src/josepy/jws.py
+++ b/src/josepy/jws.py
@@ -373,7 +373,7 @@ class CLI:
             print(sig.json_dumps_pretty())
 
     @classmethod
-    def verify(cls, args: argparse.Namespace) -> int:
+    def verify(cls, args: argparse.Namespace) -> bool:
         """Verify."""
         if args.compact:
             sig = JWS.from_compact(sys.stdin.read().encode())
@@ -382,7 +382,7 @@ class CLI:
                 sig = cast(JWS, JWS.json_loads(sys.stdin.read()))
             except errors.Error as error:
                 print(error)
-                return -1
+                return False
 
         if args.key is not None:
             assert args.kty is not None
@@ -409,7 +409,7 @@ class CLI:
         return jwk.JWK.TYPES[arg]
 
     @classmethod
-    def run(cls, args: List[str] = None) -> Any:
+    def run(cls, args: List[str] = None) -> Optional[bool]:
         """Parse arguments and sign/verify."""
         if args is None:
             args = sys.argv[1:]

--- a/src/josepy/jws.py
+++ b/src/josepy/jws.py
@@ -73,7 +73,7 @@ class Header(json_util.JSONObjectWithFields):
     cty = json_util.Field('cty', encoder=MediaType.encode,
                           decoder=MediaType.decode, omitempty=True)
     crit = json_util.Field('crit', omitempty=True, default=())
-    _fields: Dict[str, Any]
+    _fields: Dict[str, json_util.Field]
 
     def not_omitted(self) -> Dict[str, Any]:
         """Fields that would not be omitted in the JSON object."""

--- a/src/josepy/jws.py
+++ b/src/josepy/jws.py
@@ -211,7 +211,7 @@ class Signature(json_util.JSONObjectWithFields):
         :param JWK key: Key for signature.
         :param JWASignature alg: Signature algorithm to use to sign.
         :param bool include_jwk: If True, insert the JWK inside the signature headers.
-        :param set protect: List of headers to protect.
+        :param FrozenSet protect: List of headers to protect.
 
         """
         assert isinstance(key, alg.kty)

--- a/src/josepy/jws.py
+++ b/src/josepy/jws.py
@@ -75,7 +75,7 @@ class Header(json_util.JSONObjectWithFields):
     crit = json_util.Field('crit', omitempty=True, default=())
     _fields: Dict[str, json_util.Field]
 
-    def not_omitted(self) -> Dict[str, Any]:
+    def not_omitted(self) -> Dict[str, json_util.Field]:
         """Fields that would not be omitted in the JSON object."""
         return {name: getattr(self, name)
                 for name, field in self._fields.items()

--- a/src/josepy/jws.py
+++ b/src/josepy/jws.py
@@ -2,9 +2,11 @@
 import argparse
 import base64
 import sys
+from typing import Dict, Any, Optional, FrozenSet, Mapping, List, Type, cast
 
-import OpenSSL
+from OpenSSL import crypto
 
+import josepy
 from josepy import b64, errors, json_util, jwa, jwk, util
 
 
@@ -15,7 +17,7 @@ class MediaType:
     """MIME Media Type and Content Type prefix."""
 
     @classmethod
-    def decode(cls, value):
+    def decode(cls, value: str) -> str:
         """Decoder."""
         # 4.1.10
         if '/' not in value:
@@ -25,7 +27,7 @@ class MediaType:
         return value
 
     @classmethod
-    def encode(cls, value):
+    def encode(cls, value: str) -> str:
         """Encoder."""
         # 4.1.10
         if ';' not in value:
@@ -71,14 +73,15 @@ class Header(json_util.JSONObjectWithFields):
     cty = json_util.Field('cty', encoder=MediaType.encode,
                           decoder=MediaType.decode, omitempty=True)
     crit = json_util.Field('crit', omitempty=True, default=())
+    _fields: Dict[str, Any]
 
-    def not_omitted(self):
+    def not_omitted(self) -> Dict[str, Any]:
         """Fields that would not be omitted in the JSON object."""
         return {name: getattr(self, name)
                 for name, field in self._fields.items()
                 if not field.omit(getattr(self, name))}
 
-    def __add__(self, other):
+    def __add__(self, other: Any) -> 'Header':
         if not isinstance(other, type(self)):
             raise TypeError('Header cannot be added to: {0}'.format(
                 type(other)))
@@ -92,7 +95,7 @@ class Header(json_util.JSONObjectWithFields):
         not_omitted_self.update(not_omitted_other)
         return type(self)(**not_omitted_self)  # pylint: disable=star-args
 
-    def find_key(self):
+    def find_key(self) -> josepy.JWK:
         """Find key based on header.
 
         .. todo:: Supports only "jwk" header parameter lookup.
@@ -105,7 +108,7 @@ class Header(json_util.JSONObjectWithFields):
         """
         if self.jwk is None:
             raise errors.Error('No key found')
-        return self.jwk
+        return cast(josepy.JWK, self.jwk)
 
     @crit.decoder  # type: ignore
     def crit(unused_value):
@@ -117,16 +120,16 @@ class Header(json_util.JSONObjectWithFields):
 
     @x5c.encoder  # type: ignore
     def x5c(value):  # pylint: disable=missing-docstring,no-self-argument
-        return [base64.b64encode(OpenSSL.crypto.dump_certificate(
-            OpenSSL.crypto.FILETYPE_ASN1, cert.wrapped)) for cert in value]
+        return [base64.b64encode(crypto.dump_certificate(
+            crypto.FILETYPE_ASN1, cert.wrapped)) for cert in value]
 
     @x5c.decoder  # type: ignore
     def x5c(value):  # pylint: disable=missing-docstring,no-self-argument
         try:
-            return tuple(util.ComparableX509(OpenSSL.crypto.load_certificate(
-                OpenSSL.crypto.FILETYPE_ASN1,
+            return tuple(util.ComparableX509(crypto.load_certificate(
+                crypto.FILETYPE_ASN1,
                 base64.b64decode(cert))) for cert in value)
-        except OpenSSL.crypto.Error as error:
+        except crypto.Error as error:
             raise errors.DeserializationError(error)
 
 
@@ -141,6 +144,7 @@ class Signature(json_util.JSONObjectWithFields):
 
     """
     header_cls = Header
+    combined: Header
 
     __slots__ = ('combined',)
     protected = json_util.Field('protected', omitempty=True, default='')
@@ -152,22 +156,22 @@ class Signature(json_util.JSONObjectWithFields):
         encoder=json_util.encode_b64jose)
 
     @protected.encoder  # type: ignore
-    def protected(value):  # pylint: disable=missing-docstring,no-self-argument
+    def protected(value: str) -> str:  # pylint: disable=missing-docstring,no-self-argument
         # wrong type guess (Signature, not bytes) | pylint: disable=no-member
         return json_util.encode_b64jose(value.encode('utf-8'))
 
     @protected.decoder  # type: ignore
-    def protected(value):  # pylint: disable=missing-docstring,no-self-argument
+    def protected(value: str) -> str:  # pylint: disable=missing-docstring,no-self-argument
         return json_util.decode_b64jose(value).decode('utf-8')
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: Any) -> None:
         if 'combined' not in kwargs:
             kwargs = self._with_combined(kwargs)
         super().__init__(**kwargs)
         assert self.combined.alg is not None
 
     @classmethod
-    def _with_combined(cls, kwargs):
+    def _with_combined(cls, kwargs: Any) -> Dict[str, Any]:
         assert 'combined' not in kwargs
         header = kwargs.get('header', cls._fields['header'].default)
         protected = kwargs.get('protected', cls._fields['protected'].default)
@@ -181,27 +185,33 @@ class Signature(json_util.JSONObjectWithFields):
         return kwargs
 
     @classmethod
-    def _msg(cls, protected, payload):
+    def _msg(cls, protected: str, payload: bytes):
         return (b64.b64encode(protected.encode('utf-8')) + b'.' +
                 b64.b64encode(payload))
 
-    def verify(self, payload, key=None):
+    def verify(self, payload: bytes, key: Optional[josepy.JWK] = None) -> bool:
         """Verify.
 
+        :param bytes payload: Payload to verify.
         :param JWK key: Key used for verification.
 
         """
-        key = self.combined.find_key() if key is None else key
-        return self.combined.alg.verify(
-            key=key.key, sig=self.signature,
-            msg=self._msg(self.protected, payload))
+        actual_key: josepy.JWK = self.combined.find_key() if key is None else key
+        return cast(josepy.jwa.JWASignature, self.combined.alg).verify(
+            key=actual_key.key, sig=cast(bytes, self.signature),
+            msg=self._msg(cast(str, self.protected), payload))
 
     @classmethod
-    def sign(cls, payload, key, alg, include_jwk=True,
-             protect=frozenset(), **kwargs):
+    def sign(cls, payload: bytes, key: josepy.JWK, alg: josepy.JWASignature,
+             include_jwk: bool = True, protect: FrozenSet = frozenset(),
+             **kwargs: Any) -> 'Signature':
         """Sign.
 
+        :param bytes payload: Payload to sign.
         :param JWK key: Key for signature.
+        :param JWASignature alg: Signature algorithm to use to sign.
+        :param bool include_jwk: If True, insert the JWK inside the signature headers.
+        :param set protect: List of headers to protect.
 
         """
         assert isinstance(key, alg.kty)
@@ -229,14 +239,14 @@ class Signature(json_util.JSONObjectWithFields):
 
         return cls(protected=protected, header=header, signature=signature)
 
-    def fields_to_partial_json(self):
+    def fields_to_partial_json(self) -> Dict[str, Any]:
         fields = super().fields_to_partial_json()
         if not fields['header'].not_omitted():
             del fields['header']
         return fields
 
     @classmethod
-    def fields_from_json(cls, jobj):
+    def fields_from_json(cls, jobj: Mapping[str, Any]) -> Dict[str, Any]:
         fields = super().fields_from_json(jobj)
         fields_with_combined = cls._with_combined(fields)
         if 'alg' not in fields_with_combined['combined'].not_omitted():
@@ -252,21 +262,23 @@ class JWS(json_util.JSONObjectWithFields):
 
     """
     __slots__ = ('payload', 'signatures')
+    payload: bytes
+    signatures: List[Signature]
 
     signature_cls = Signature
 
-    def verify(self, key=None):
+    def verify(self, key: Optional[josepy.JWK] = None) -> bool:
         """Verify."""
         return all(sig.verify(self.payload, key) for sig in self.signatures)
 
     @classmethod
-    def sign(cls, payload, **kwargs):
+    def sign(cls, payload: bytes, **kwargs: Any) -> 'JWS':
         """Sign."""
         return cls(payload=payload, signatures=(
             cls.signature_cls.sign(payload=payload, **kwargs),))
 
     @property
-    def signature(self):
+    def signature(self) -> Signature:
         """Get a singleton signature.
 
         :rtype: :class:`JWS.signature_cls`
@@ -275,7 +287,7 @@ class JWS(json_util.JSONObjectWithFields):
         assert len(self.signatures) == 1
         return self.signatures[0]
 
-    def to_compact(self):
+    def to_compact(self) -> bytes:
         """Compact serialization.
 
         :rtype: bytes
@@ -283,7 +295,7 @@ class JWS(json_util.JSONObjectWithFields):
         """
         assert len(self.signatures) == 1
 
-        assert 'alg' not in self.signature.header.not_omitted()
+        assert 'alg' not in cast(Header, self.signature.header).not_omitted()
         # ... it must be in protected
 
         return (
@@ -291,10 +303,10 @@ class JWS(json_util.JSONObjectWithFields):
             b'.' +
             b64.b64encode(self.payload) +
             b'.' +
-            b64.b64encode(self.signature.signature))
+            b64.b64encode(cast(bytes, self.signature.signature)))
 
     @classmethod
-    def from_compact(cls, compact):
+    def from_compact(cls, compact: bytes) -> 'JWS':
         """Compact deserialization.
 
         :param bytes compact:
@@ -312,7 +324,7 @@ class JWS(json_util.JSONObjectWithFields):
             signature=b64.b64decode(signature))
         return cls(payload=b64.b64decode(payload), signatures=(sig,))
 
-    def to_partial_json(self, flat=True):  # pylint: disable=arguments-differ
+    def to_partial_json(self, flat: bool = True) -> Dict[str, Any]:  # pylint: disable=arguments-differ
         assert self.signatures
         payload = json_util.encode_b64jose(self.payload)
 
@@ -327,7 +339,7 @@ class JWS(json_util.JSONObjectWithFields):
             }
 
     @classmethod
-    def from_json(cls, jobj):
+    def from_json(cls, jobj: Dict[str, Any]) -> 'JWS':
         if 'signature' in jobj and 'signatures' in jobj:
             raise errors.DeserializationError('Flat mixed with non-flat')
         elif 'signature' in jobj:  # flat
@@ -343,7 +355,7 @@ class CLI:
     """JWS CLI."""
 
     @classmethod
-    def sign(cls, args):
+    def sign(cls, args: argparse.Namespace) -> None:
         """Sign."""
         key = args.alg.kty.load(args.key.read())
         args.key.close()
@@ -361,13 +373,13 @@ class CLI:
             print(sig.json_dumps_pretty())
 
     @classmethod
-    def verify(cls, args):
+    def verify(cls, args: argparse.Namespace) -> int:
         """Verify."""
         if args.compact:
             sig = JWS.from_compact(sys.stdin.read().encode())
         else:  # JSON
             try:
-                sig = JWS.json_loads(sys.stdin.read())
+                sig = cast(JWS, JWS.json_loads(sys.stdin.read()))
             except errors.Error as error:
                 print(error)
                 return -1
@@ -379,25 +391,25 @@ class CLI:
         else:
             key = None
 
-        sys.stdout.write(sig.payload)
+        sys.stdout.write(sig.payload.decode())
         return not sig.verify(key=key)
 
     @classmethod
-    def _alg_type(cls, arg):
+    def _alg_type(cls, arg: Any) -> jwa.JWASignature:
         return jwa.JWASignature.from_json(arg)
 
     @classmethod
-    def _header_type(cls, arg):
+    def _header_type(cls, arg: Any) -> Any:
         assert arg in Signature.header_cls._fields
         return arg
 
     @classmethod
-    def _kty_type(cls, arg):
+    def _kty_type(cls, arg: Any) -> Type[jwk.JWK]:
         assert arg in jwk.JWK.TYPES
         return jwk.JWK.TYPES[arg]
 
     @classmethod
-    def run(cls, args=None):
+    def run(cls, args: List[str] = None) -> Any:
         """Parse arguments and sign/verify."""
         if args is None:
             args = sys.argv[1:]

--- a/src/josepy/jws_test.py
+++ b/src/josepy/jws_test.py
@@ -202,7 +202,7 @@ class CLITest(unittest.TestCase):
         with mock.patch('sys.stdin') as sin:
             sin.read.return_value = '{"payload": "foo", "signature": "xxx"}'
             with mock.patch('sys.stdout'):
-                self.assertEqual(-1, CLI.run(['verify']))
+                self.assertEqual(False, CLI.run(['verify']))
 
     def test_json(self):
         from josepy.jws import CLI

--- a/src/josepy/magic_typing.py
+++ b/src/josepy/magic_typing.py
@@ -2,6 +2,7 @@
 # mypy: ignore-errors
 import sys
 import warnings
+from typing import Any
 
 
 warnings.warn("josepy.magic_typing is deprecated and will be removed in a future release.",
@@ -10,7 +11,7 @@ warnings.warn("josepy.magic_typing is deprecated and will be removed in a future
 
 class TypingClass:
     """Ignore import errors by getting anything"""
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> Any:
         return None
 
 

--- a/src/josepy/test_util.py
+++ b/src/josepy/test_util.py
@@ -4,8 +4,10 @@
 
 """
 import os
+from typing import Any
 
-import OpenSSL
+import josepy.util
+from OpenSSL import crypto
 import pkg_resources
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
@@ -14,20 +16,20 @@ from josepy import ComparableRSAKey, ComparableX509
 from josepy.util import ComparableECKey
 
 
-def vector_path(*names):
+def vector_path(*names: str) -> str:
     """Path to a test vector."""
     return pkg_resources.resource_filename(
         __name__, os.path.join('testdata', *names))
 
 
-def load_vector(*names):
+def load_vector(*names: str) -> bytes:
     """Load contents of a test vector."""
     # luckily, resource_string opens file in binary mode
     return pkg_resources.resource_string(
         __name__, os.path.join('testdata', *names))
 
 
-def _guess_loader(filename, loader_pem, loader_der):
+def _guess_loader(filename: str, loader_pem: Any, loader_der: Any) -> Any:
     _, ext = os.path.splitext(filename)
     if ext.lower() == '.pem':
         return loader_pem
@@ -37,31 +39,31 @@ def _guess_loader(filename, loader_pem, loader_der):
         raise ValueError("Loader could not be recognized based on extension")
 
 
-def load_cert(*names):
+def load_cert(*names: str) -> crypto.X509:
     """Load certificate."""
     loader = _guess_loader(
-        names[-1], OpenSSL.crypto.FILETYPE_PEM, OpenSSL.crypto.FILETYPE_ASN1)
-    return OpenSSL.crypto.load_certificate(loader, load_vector(*names))
+        names[-1], crypto.FILETYPE_PEM, crypto.FILETYPE_ASN1)
+    return crypto.load_certificate(loader, load_vector(*names))
 
 
-def load_comparable_cert(*names):
+def load_comparable_cert(*names: str) -> josepy.util.ComparableX509:
     """Load ComparableX509 cert."""
     return ComparableX509(load_cert(*names))
 
 
-def load_csr(*names):
+def load_csr(*names: str) -> crypto.X509Req:
     """Load certificate request."""
     loader = _guess_loader(
-        names[-1], OpenSSL.crypto.FILETYPE_PEM, OpenSSL.crypto.FILETYPE_ASN1)
-    return OpenSSL.crypto.load_certificate_request(loader, load_vector(*names))
+        names[-1], crypto.FILETYPE_PEM, crypto.FILETYPE_ASN1)
+    return crypto.load_certificate_request(loader, load_vector(*names))
 
 
-def load_comparable_csr(*names):
+def load_comparable_csr(*names: str) -> josepy.util.ComparableX509:
     """Load ComparableX509 certificate request."""
     return ComparableX509(load_csr(*names))
 
 
-def load_rsa_private_key(*names):
+def load_rsa_private_key(*names: str) -> josepy.util.ComparableRSAKey:
     """Load RSA private key."""
     loader = _guess_loader(names[-1], serialization.load_pem_private_key,
                            serialization.load_der_private_key)
@@ -69,7 +71,7 @@ def load_rsa_private_key(*names):
         load_vector(*names), password=None, backend=default_backend()))
 
 
-def load_ec_private_key(*names):
+def load_ec_private_key(*names: str) -> josepy.util.ComparableECKey:
     """Load EC private key."""
     loader = _guess_loader(names[-1], serialization.load_pem_private_key,
                            serialization.load_der_private_key)
@@ -77,8 +79,8 @@ def load_ec_private_key(*names):
         load_vector(*names), password=None, backend=default_backend()))
 
 
-def load_pyopenssl_private_key(*names):
+def load_pyopenssl_private_key(*names: str) -> crypto.PKey:
     """Load pyOpenSSL private key."""
     loader = _guess_loader(
-        names[-1], OpenSSL.crypto.FILETYPE_PEM, OpenSSL.crypto.FILETYPE_ASN1)
-    return OpenSSL.crypto.load_privatekey(loader, load_vector(*names))
+        names[-1], crypto.FILETYPE_PEM, crypto.FILETYPE_ASN1)
+    return crypto.load_privatekey(loader, load_vector(*names))

--- a/src/josepy/util.py
+++ b/src/josepy/util.py
@@ -7,7 +7,6 @@ import sys
 import warnings
 
 from OpenSSL import crypto
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
 
 

--- a/src/josepy/util.py
+++ b/src/josepy/util.py
@@ -1,29 +1,10 @@
 """JOSE utilities."""
+from typing import Union, Any, Callable, Iterator, Tuple
 from collections.abc import Hashable, Mapping
 
-import OpenSSL
+from OpenSSL import crypto
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
-
-
-class abstractclassmethod(classmethod):
-    # pylint: disable=invalid-name,too-few-public-methods
-    """Descriptor for an abstract classmethod.
-
-    It augments the :mod:`abc` framework with an abstract
-    classmethod. This is implemented as :class:`abc.abstractclassmethod`
-    in the standard Python library starting with version 3.2.
-
-    This implementation is from a StackOverflow answer that was derived from
-    the implementation in the Python 3.3 abc library.
-    http://stackoverflow.com/questions/11217878/python-2-7-combine-abc-abstractmethod-and-classmethod.
-
-    """
-    __isabstractmethod__ = True
-
-    def __init__(self, target):
-        target.__isabstractmethod__ = True
-        super().__init__(target)
 
 
 class ComparableX509:  # pylint: disable=too-few-public-methods
@@ -34,15 +15,15 @@ class ComparableX509:  # pylint: disable=too-few-public-methods
 
     """
 
-    def __init__(self, wrapped):
-        assert isinstance(wrapped, OpenSSL.crypto.X509) or isinstance(
-            wrapped, OpenSSL.crypto.X509Req)
+    def __init__(self, wrapped: Union[crypto.X509, crypto.X509Req]) -> None:
+        assert isinstance(wrapped, crypto.X509) or isinstance(
+            wrapped, crypto.X509Req)
         self.wrapped = wrapped
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> Any:
         return getattr(self.wrapped, name)
 
-    def _dump(self, filetype=OpenSSL.crypto.FILETYPE_ASN1):
+    def _dump(self, filetype: int = crypto.FILETYPE_ASN1) -> bytes:
         """Dumps the object into a buffer with the specified encoding.
 
         :param int filetype: The desired encoding. Should be one of
@@ -54,22 +35,22 @@ class ComparableX509:  # pylint: disable=too-few-public-methods
         :rtype: str
 
         """
-        if isinstance(self.wrapped, OpenSSL.crypto.X509):
-            func = OpenSSL.crypto.dump_certificate
-        else:  # assert in __init__ makes sure this is X509Req
-            func = OpenSSL.crypto.dump_certificate_request
-        return func(filetype, self.wrapped)
+        if isinstance(self.wrapped, crypto.X509):
+            return crypto.dump_certificate(filetype, self.wrapped)
 
-    def __eq__(self, other):
+        # assert in __init__ makes sure this is X509Req
+        return crypto.dump_certificate_request(filetype, self.wrapped)
+
+    def __eq__(self, other: Any) -> bool:
         if not isinstance(other, self.__class__):
             return NotImplemented
         # pylint: disable=protected-access
         return self._dump() == other._dump()
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash((self.__class__, self._dump()))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '<{0}({1!r})>'.format(self.__class__.__name__, self.wrapped)
 
 
@@ -79,15 +60,20 @@ class ComparableKey:  # pylint: disable=too-few-public-methods
     See https://github.com/pyca/cryptography/issues/2122.
 
     """
-    __hash__ = NotImplemented
+    __hash__: Callable[[], int] = NotImplemented
 
-    def __init__(self, wrapped):
+    def __init__(self,
+                 wrapped: Union[
+                     rsa.RSAPrivateKeyWithSerialization,
+                     rsa.RSAPublicKeyWithSerialization,
+                     ec.EllipticCurvePrivateKeyWithSerialization,
+                     ec.EllipticCurvePublicKeyWithSerialization]):
         self._wrapped = wrapped
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> Any:
         return getattr(self._wrapped, name)
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         # pylint: disable=protected-access
         if (not isinstance(other, self.__class__) or
                 self._wrapped.__class__ is not other._wrapped.__class__):
@@ -99,12 +85,12 @@ class ComparableKey:  # pylint: disable=too-few-public-methods
         else:
             return NotImplemented
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '<{0}({1!r})>'.format(self.__class__.__name__, self._wrapped)
 
-    def public_key(self):
+    def public_key(self) -> 'ComparableKey':
         """Get wrapped public key."""
-        return self.__class__(self._wrapped.public_key())
+        return self.__class__(self._wrapped.public_key())  # type: ignore[union-attr]
 
 
 class ComparableRSAKey(ComparableKey):  # pylint: disable=too-few-public-methods
@@ -117,7 +103,7 @@ class ComparableRSAKey(ComparableKey):  # pylint: disable=too-few-public-methods
 
     """
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         # public_numbers() hasn't got stable hash!
         # https://github.com/pyca/cryptography/issues/2143
         if isinstance(self._wrapped, rsa.RSAPrivateKeyWithSerialization):
@@ -129,6 +115,8 @@ class ComparableRSAKey(ComparableKey):  # pylint: disable=too-few-public-methods
             pub = self.public_numbers()
             return hash((self.__class__, pub.n, pub.e))
 
+        raise NotImplementedError()
+
 
 class ComparableECKey(ComparableKey):  # pylint: disable=too-few-public-methods
     """Wrapper for ``cryptography`` RSA keys.
@@ -137,7 +125,7 @@ class ComparableECKey(ComparableKey):  # pylint: disable=too-few-public-methods
     - :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKey`
     """
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         # public_numbers() hasn't got stable hash!
         # https://github.com/pyca/cryptography/issues/2143
         if isinstance(self._wrapped, ec.EllipticCurvePrivateKeyWithSerialization):
@@ -148,13 +136,15 @@ class ComparableECKey(ComparableKey):  # pylint: disable=too-few-public-methods
             pub = self.public_numbers()
             return hash((self.__class__, pub.curve.name, pub.x, pub.y))
 
-    def public_key(self):
+        raise NotImplementedError()
+
+    def public_key(self) -> 'ComparableECKey':
         """Get wrapped public key."""
         # Unlike RSAPrivateKey, EllipticCurvePrivateKey does not have public_key()
         if hasattr(self._wrapped, 'public_key'):
-            key = self._wrapped.public_key()
+            key = self._wrapped.public_key()  # type: ignore[union-attr]
         else:
-            key = self._wrapped.public_numbers().public_key(default_backend())
+            key = self._wrapped.public_numbers().public_key(default_backend())  # type: ignore[union-attr]
         return self.__class__(key)
 
 
@@ -162,10 +152,10 @@ class ImmutableMap(Mapping, Hashable):
     # pylint: disable=too-few-public-methods
     """Immutable key to value mapping with attribute access."""
 
-    __slots__ = ()
+    __slots__: Tuple[str, ...] = ()
     """Must be overridden in subclasses."""
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: Any) -> None:
         if set(kwargs) != set(self.__slots__):
             raise TypeError(
                 '__init__() takes exactly the following arguments: {0} '
@@ -174,30 +164,30 @@ class ImmutableMap(Mapping, Hashable):
         for slot in self.__slots__:
             object.__setattr__(self, slot, kwargs.pop(slot))
 
-    def update(self, **kwargs):
+    def update(self, **kwargs: Any) -> 'ImmutableMap':
         """Return updated map."""
         items = {**self, **kwargs}
         return type(self)(**items)  # pylint: disable=star-args
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> Any:
         try:
             return getattr(self, key)
         except AttributeError:
             raise KeyError(key)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[str]:
         return iter(self.__slots__)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.__slots__)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(tuple(getattr(self, slot) for slot in self.__slots__))
 
-    def __setattr__(self, name, value):
+    def __setattr__(self, name: str, value: Any) -> None:
         raise AttributeError("can't set attribute")
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '{0}({1})'.format(self.__class__.__name__, ', '.join(
             '{0}={1!r}'.format(key, value)
             for key, value in self.items()))
@@ -208,7 +198,8 @@ class frozendict(Mapping, Hashable):
     """Frozen dictionary."""
     __slots__ = ('_items', '_keys')
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        items: Mapping
         if kwargs and not args:
             items = dict(kwargs)
         elif len(args) == 1 and isinstance(args[0], Mapping):
@@ -220,30 +211,30 @@ class frozendict(Mapping, Hashable):
         object.__setattr__(self, '_items', items)
         object.__setattr__(self, '_keys', tuple(sorted(items.keys())))
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> Any:
         return self._items[key]
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[str]:
         return iter(self._keys)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._items)
 
-    def _sorted_items(self):
+    def _sorted_items(self) -> Tuple[Tuple[str, Any], ...]:
         return tuple((key, self[key]) for key in self._keys)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self._sorted_items())
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> Any:
         try:
             return self._items[name]
         except KeyError:
             raise AttributeError(name)
 
-    def __setattr__(self, name, value):
+    def __setattr__(self, name: str, value: Any) -> None:
         raise AttributeError("can't set attribute")
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'frozendict({0})'.format(', '.join('{0}={1!r}'.format(
             key, value) for key, value in self._sorted_items()))

--- a/src/josepy/util.py
+++ b/src/josepy/util.py
@@ -103,8 +103,7 @@ class ComparableKey:  # pylint: disable=too-few-public-methods
                                       ec.EllipticCurvePublicKeyWithSerialization)):
             return self
 
-        key = self._wrapped.private_numbers().public_numbers.public_key(default_backend())
-        return self.__class__(key)
+        return self.__class__(self._wrapped.public_key())
 
 
 class ComparableRSAKey(ComparableKey):  # pylint: disable=too-few-public-methods

--- a/src/josepy/util.py
+++ b/src/josepy/util.py
@@ -11,6 +11,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
 
 
+# Deprecated. Please use built-in decorators @classmethod and abc.abstractmethod together instead.
 def abstractclassmethod(func: Callable):
     return classmethod(abc.abstractmethod(func))
 

--- a/src/josepy/util.py
+++ b/src/josepy/util.py
@@ -264,7 +264,7 @@ class _UtilDeprecationModule:
         if attr == 'abstractclassmethod':
             warnings.warn('The abstractclassmethod attribute in josepy.util is deprecated and will '
                           'be removed soon. Please use the built-in decorators @classmethod and '
-                          '@abc.abstractmethod together instead',
+                          '@abc.abstractmethod together instead.',
                           DeprecationWarning, stacklevel=2)
         return getattr(self._module, attr)
 


### PR DESCRIPTION
As part of a global effort to bring more types in the Certbot project, this PR adds type annotations to all methods/functions in `josepy` out of tests modules.
