### PR TITLE
Allow to add type annotations to fields defined in a `JSONObjectWithFields`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 1.10.0 (master)
 ---------------
 
+* josepy is now compliant with PEP-561: type checkers will fetch types from the inline
+  types annotations when josepy is installed as a dependency in a Python project.
 * Added a `field` function to assist in adding type annotations for Fields in classes.
   If the field function is used to define a `Field` in a `JSONObjectWithFields` based
   class without a type annotation, an error will be raised.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Changelog
 1.10.0 (master)
 ---------------
 
+* Added a `field` function to assist in adding type annotations for Fields in classes.
+  If the field function is used to define a `Field` in a `JSONObjectWithFields` based
+  class without a type annotation, an error will be raised.
+
 1.9.0 (2021-09-09)
 ------------------
 

--- a/src/josepy/__init__.py
+++ b/src/josepy/__init__.py
@@ -52,6 +52,7 @@ from josepy.json_util import (
     encode_cert,
     encode_csr,
     encode_hex16,
+    field,
 )
 
 from josepy.jwa import (

--- a/src/josepy/json_util.py
+++ b/src/josepy/json_util.py
@@ -148,7 +148,7 @@ class _TypedField(Field):
     This class is kept private because fields are supposed to be declared
     using the :function:`field` in this situation.
 
-    In the future the :class:`Field` will be removed in favor of this one."""
+    In the future the :class:`Field` may be removed in favor of this one."""
 
 
 class JSONObjectWithFieldsMeta(abc.ABCMeta):

--- a/src/josepy/json_util.py
+++ b/src/josepy/json_util.py
@@ -19,6 +19,24 @@ from josepy import b64, errors, interfaces, util
 logger = logging.getLogger(__name__)
 
 
+def field(json_name: str, default: Any = None, omitempty: bool = False,
+          decoder: Callable[[Any], Any] = None, encoder: Callable[[Any], Any] = None) -> Any:
+    """Convenient function to declare a :class:`Field` with proper type annotations.
+
+    This function allows to write the following code:
+
+    import josepy
+    class JSON(josepy.JSONObjectWithFields):
+        typ: str = josepy.field('type')
+
+        def other_type(self) -> str:
+            return self.typ
+
+    """
+    return Field(json_name=json_name, default=default, omitempty=omitempty,
+                 decoder=decoder, encoder=encoder)
+
+
 class Field:
     """JSON object field.
 

--- a/src/josepy/json_util.py
+++ b/src/josepy/json_util.py
@@ -206,7 +206,7 @@ class JSONObjectWithFieldsMeta(abc.ABCMeta):
                 if isinstance(value, _TypedField):
                     # Ensure the type annotation has been set for the field.
                     # Error out if it is not the case.
-                    if not namespace.get('__annotations__', {}).get(key):
+                    if key not in namespace.get('__annotations__', {}):
                         raise ValueError(
                             f'Field `{key}` in JSONObject `{name}` has no type annotation.')
                 fields[key] = namespace.pop(key)

--- a/src/josepy/json_util.py
+++ b/src/josepy/json_util.py
@@ -33,8 +33,8 @@ def field(json_name: str, default: Any = None, omitempty: bool = False,
             return self.typ
 
     """
-    return Field(json_name=json_name, default=default, omitempty=omitempty,
-                 decoder=decoder, encoder=encoder)
+    return _TypedField(json_name=json_name, default=default, omitempty=omitempty,
+                       decoder=decoder, encoder=encoder)
 
 
 class Field:
@@ -142,6 +142,15 @@ class Field:
         return value
 
 
+class _TypedField(Field):
+    """Specialized class to mark a JSON object field with typed annotations.
+
+    This class is kept private because fields are supposed to be declared
+    using the :function:`field` in this situation.
+
+    In the future the :class:`Field` will be removed in favor of this one."""
+
+
 class JSONObjectWithFieldsMeta(abc.ABCMeta):
     """Metaclass for :class:`JSONObjectWithFields` and its subclasses.
 
@@ -185,24 +194,29 @@ class JSONObjectWithFieldsMeta(abc.ABCMeta):
     _fields: Dict[str, Field] = {}
 
     def __new__(mcs, name: str, bases: List[str],
-                dikt: Dict[str, Any]) -> 'JSONObjectWithFieldsMeta':
+                namespace: Dict[str, Any]) -> 'JSONObjectWithFieldsMeta':
         fields = {}
 
         for base in bases:
             fields.update(getattr(base, '_fields', {}))
         # Do not reorder, this class might override fields from base classes!
-        # We create a tuple based on dikt.items() here because the loop
-        # modifies dikt.
-        for key, value in tuple(dikt.items()):
+        # We use a copy of namespace in the loop because the loop modifies it.
+        for key, value in namespace.copy().items():
             if isinstance(value, Field):
-                fields[key] = dikt.pop(key)
+                if isinstance(value, _TypedField):
+                    # Ensure the type annotation has been set for the field.
+                    # Error out if it is not the case.
+                    if not namespace.get('__annotations__', {}).get(key):
+                        raise ValueError(
+                            f'Field `{key}` in JSONObject `{name}` has no type annotation.')
+                fields[key] = namespace.pop(key)
 
-        dikt['_orig_slots'] = dikt.get('__slots__', ())
-        dikt['__slots__'] = tuple(
-            list(dikt['_orig_slots']) + list(fields.keys()))
-        dikt['_fields'] = fields
+        namespace['_orig_slots'] = namespace.get('__slots__', ())
+        namespace['__slots__'] = tuple(
+            list(namespace['_orig_slots']) + list(fields.keys()))
+        namespace['_fields'] = fields
 
-        return abc.ABCMeta.__new__(mcs, name, bases, dikt)  # type: ignore[call-overload]
+        return abc.ABCMeta.__new__(mcs, name, bases, namespace)  # type: ignore[call-overload]
 
 
 class JSONObjectWithFields(util.ImmutableMap,

--- a/src/josepy/json_util_test.py
+++ b/src/josepy/json_util_test.py
@@ -20,6 +20,18 @@ class FieldTest(unittest.TestCase):
         self.assertEqual(test.json_name, "foo")
         self.assertEqual(test.default, "bar")
 
+    def test_type_field_control(self):
+        from josepy.json_util import field, JSONObjectWithFields
+
+        class DummyProperlyTyped(JSONObjectWithFields):
+            type: str = field('type')
+            index: int = field('index')
+
+        with self.assertRaises(ValueError):
+            class DummyImproperlyTyped(JSONObjectWithFields):
+                type = field('type')
+                index: int = field('index')
+
     def test_no_omit_boolean(self):
         from josepy.json_util import Field
         for default, omitempty, value in itertools.product(

--- a/src/josepy/json_util_test.py
+++ b/src/josepy/json_util_test.py
@@ -10,7 +10,15 @@ CSR = test_util.load_comparable_csr('csr.pem')
 
 
 class FieldTest(unittest.TestCase):
-    """Tests for josepy.json_util.Field."""
+    """Tests for josepy.json_util.field and josepy.json_util.Field."""
+
+    def test_field_function(self):
+        from josepy.json_util import field, Field
+
+        test = field("foo", default="bar")
+        self.assertIsInstance(test, Field)
+        self.assertEqual(test.json_name, "foo")
+        self.assertEqual(test.default, "bar")
 
     def test_no_omit_boolean(self):
         from josepy.json_util import Field

--- a/src/josepy/jws.py
+++ b/src/josepy/jws.py
@@ -2,7 +2,7 @@
 import argparse
 import base64
 import sys
-from typing import Dict, Any, Optional, FrozenSet, Mapping, List, Type, cast
+from typing import Dict, Any, Optional, FrozenSet, Mapping, List, Type, Tuple, cast
 
 from OpenSSL import crypto
 
@@ -63,7 +63,7 @@ class Header(json_util.JSONObjectWithFields):
     jwk: jwk_mod.JWK = json_util.field('jwk', decoder=jwk_mod.JWK.from_json, omitempty=True)
     kid: bytes = json_util.field('kid', omitempty=True)
     x5u: bytes = json_util.field('x5u', omitempty=True)
-    x5c: bytes = json_util.field('x5c', omitempty=True, default=())
+    x5c: Tuple[util.ComparableX509, ...] = json_util.field('x5c', omitempty=True, default=())
     x5t: bytes = json_util.field(
         'x5t', decoder=json_util.decode_b64jose, omitempty=True)
     x5tS256: bytes = json_util.field(
@@ -72,7 +72,7 @@ class Header(json_util.JSONObjectWithFields):
                                      decoder=MediaType.decode, omitempty=True)
     cty: MediaType = json_util.field('cty', encoder=MediaType.encode,
                                      decoder=MediaType.decode, omitempty=True)
-    crit: bytes = json_util.field('crit', omitempty=True, default=())
+    crit: Tuple[Any, ...] = json_util.field('crit', omitempty=True, default=())
     _fields: Dict[str, json_util.Field]
 
     def not_omitted(self) -> Dict[str, json_util.Field]:

--- a/src/josepy/jws.py
+++ b/src/josepy/jws.py
@@ -7,7 +7,7 @@ from typing import Dict, Any, Optional, FrozenSet, Mapping, List, Type, cast
 from OpenSSL import crypto
 
 import josepy
-from josepy import b64, errors, json_util, jwa, jwk, util
+from josepy import b64, errors, json_util, jwa, jwk as jwk_mod, util
 
 
 class MediaType:
@@ -60,7 +60,7 @@ class Header(json_util.JSONObjectWithFields):
     alg: jwa.JWASignature = json_util.field(
         'alg', decoder=jwa.JWASignature.from_json, omitempty=True)
     jku: bytes = json_util.field('jku', omitempty=True)
-    jwk: jwk.JWK = json_util.field('jwk', decoder=jwk.JWK.from_json, omitempty=True)
+    jwk: jwk_mod.JWK = json_util.field('jwk', decoder=jwk_mod.JWK.from_json, omitempty=True)
     kid: bytes = json_util.field('kid', omitempty=True)
     x5u: bytes = json_util.field('x5u', omitempty=True)
     x5c: bytes = json_util.field('x5c', omitempty=True, default=())
@@ -404,9 +404,9 @@ class CLI:
         return arg
 
     @classmethod
-    def _kty_type(cls, arg: Any) -> Type[jwk.JWK]:
-        assert arg in jwk.JWK.TYPES
-        return jwk.JWK.TYPES[arg]
+    def _kty_type(cls, arg: Any) -> Type[jwk_mod.JWK]:
+        assert arg in jwk_mod.JWK.TYPES
+        return jwk_mod.JWK.TYPES[arg]
 
     @classmethod
     def run(cls, args: List[str] = None) -> Optional[bool]:


### PR DESCRIPTION
This PR provides a new function, `josepy.field`, that allows to declare fields with appropriate type annotations to express the type of the actual value of the field. An exemple is provided in the associated docstring, and actual usage of it is done in the `jws` module.
