### PR TITLE
Make `josepy` PEP-561 compliant to auto-discover inline types annotations

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,5 +3,6 @@ include CONTRIBUTING.md
 include LICENSE.txt
 include README.rst
 include .coveragerc pytest.ini tox.ini
+include src/josepy/py.typed
 recursive-include docs *
 recursive-include src/josepy/testdata *


### PR DESCRIPTION
This PR adds the required update to `josepy` to be compliant with [PEP-561](https://www.python.org/dev/peps/pep-0561/).

Once merged and a new version is released, third parties that rely on `josepy` will get their type utilities inspecting the code of `josepy` so that inline type annotations are taken into account in type checks.

Basically, no more `Skipping analyzing josepy: found module but no type hints or library stubs`.
