### PR TITLE
Test all branches

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -49,8 +49,9 @@ jobs:
         with:
           fail_ci_if_error: true
   notify:
-    # Only notify about failed builds for branches (not PRs).
-    if: ${{ failure() && github.event_name != 'pull_request' }}
+    # Only notify about failed builds, do not notify about failed builds for
+    # PRs, and only notify about failed pushes to master.
+    if: ${{ failure() && github.event_name != 'pull_request' && (github.event_name != 'push' || github.ref == 'refs/heads/master') }}
     needs: build
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -5,8 +5,6 @@ on:
     branches:
       - master
   push:
-    branches:
-      - master
   schedule:
     # Run at 4pm UTC or 9am PST
     - cron: "0 16 * * *"


### PR DESCRIPTION
Prior to https://github.com/certbot/josepy/pull/104, CI was configured to run tests on pushes to all branches. I personally find this setup useful as I've since resorted to things like [opening a draft PR if I want to test things in CI](https://github.com/certbot/josepy/pull/123).