### PR TITLE
Add missing imports to __init__

### DIFF
--- a/src/josepy/__init__.py
+++ b/src/josepy/__init__.py
@@ -73,6 +73,8 @@ from josepy.jwa import (
 
 from josepy.jwk import (
     JWK,
+    JWKEC,
+    JWKOct,
     JWKRSA,
 )
 
@@ -83,6 +85,7 @@ from josepy.jws import (
 )
 
 from josepy.util import (
+    ComparableECKey,
     ComparableX509,
     ComparableKey,
     ComparableRSAKey,


### PR DESCRIPTION
I'm not sure if those were left out intentionally.