### PR TITLE
Introduce linting (flake8 and isort)

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -41,6 +41,11 @@ jobs:
       # STATIC CHECK
       - name: Run mypy
         run: tox -e mypy
+      # LINTING
+      - name: Run flake8 and isort
+        run:
+          tox -e flake8
+          tox -e isort
       # COVERAGE
       - name: Convert Coverage
         run: python -m coverage xml

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,5 +11,5 @@ combine_as_imports = false
 default_section = THIRDPARTY
 include_trailing_comma = true
 known_first_party = josepy
-line_length = 79
+line_length = 100
 multi_line_output = 3

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,5 +11,5 @@ combine_as_imports = false
 default_section = THIRDPARTY
 include_trailing_comma = true
 known_first_party = josepy
-line_length = 100
+line_length = 79
 multi_line_output = 3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,15 @@
 [bdist_wheel]
 universal = 1
+
+[flake8]
+exclude = .git,.tox
+ignore = W504, E501
+max-line-length = 100
+
+[isort]
+combine_as_imports = false
+default_section = THIRDPARTY
+include_trailing_comma = true
+known_first_party = josepy
+line_length = 79
+multi_line_output = 3

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ universal = 1
 
 [flake8]
 exclude = .git,.tox
-ignore = W504, E501
+ignore = W504
 max-line-length = 100
 
 [isort]

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ testing_requires = [
     'coverage>=4.0',
     # Issue with flake8 4.0.0 and 4.0.1, see https://github.com/tholo/pytest-flake8/issues/81
     'flake8<4',
+    'isort',
     'mypy',
     'pytest-cov',
     'pytest-flake8>=0.5',

--- a/src/josepy/__init__.py
+++ b/src/josepy/__init__.py
@@ -26,20 +26,14 @@ Originally developed as part of the ACME_ protocol implementation.
 
 """
 # flake8: noqa
-from josepy.b64 import (
-    b64decode,
-    b64encode,
-)
-
+from josepy.b64 import b64decode, b64encode
 from josepy.errors import (
     DeserializationError,
-    SerializationError,
     Error,
+    SerializationError,
     UnrecognizedTypeError,
 )
-
 from josepy.interfaces import JSONDeSerializable
-
 from josepy.json_util import (
     Field,
     JSONObjectWithFields,
@@ -54,40 +48,27 @@ from josepy.json_util import (
     encode_hex16,
     field,
 )
-
 from josepy.jwa import (
+    ES256,
+    ES384,
+    ES512,
     HS256,
     HS384,
     HS512,
-    JWASignature,
     PS256,
     PS384,
     PS512,
     RS256,
     RS384,
     RS512,
-    ES256,
-    ES384,
-    ES512,
+    JWASignature,
 )
-
-from josepy.jwk import (
-    JWK,
-    JWKEC,
-    JWKOct,
-    JWKRSA,
-)
-
-from josepy.jws import (
-    Header,
-    JWS,
-    Signature,
-)
-
+from josepy.jwk import JWK, JWKEC, JWKRSA, JWKOct
+from josepy.jws import JWS, Header, Signature
 from josepy.util import (
     ComparableECKey,
-    ComparableX509,
     ComparableKey,
     ComparableRSAKey,
+    ComparableX509,
     ImmutableMap,
 )

--- a/src/josepy/interfaces.py
+++ b/src/josepy/interfaces.py
@@ -1,11 +1,10 @@
 """JOSE interfaces."""
 import abc
 import json
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 from josepy import errors
-
-from collections.abc import Sequence, Mapping
 
 # pylint: disable=no-self-argument,no-method-argument,no-init,inherit-non-class
 # pylint: disable=too-few-public-methods

--- a/src/josepy/json_util.py
+++ b/src/josepy/json_util.py
@@ -325,13 +325,14 @@ class JSONObjectWithFields(util.ImmutableMap,
                 try:
                     fields[slot] = field.decode(value)
                 except errors.DeserializationError as error:
-                    raise errors.DeserializationError(
-                        'Could not decode {0!r} ({1!r}): {2}'.format(
-                            slot, value, error))
+                    raise errors.DeserializationError('Could not decode {0!r} ({1!r}): {2}'.format(
+                        slot, value, error))
         return fields
 
     @classmethod
-    def from_json(cls: Type[GenericJSONObjectWithFields], jobj: Mapping[str, Any]) -> GenericJSONObjectWithFields:
+    def from_json(
+        cls: Type[GenericJSONObjectWithFields], jobj: Mapping[str, Any]
+    ) -> GenericJSONObjectWithFields:
         return cls(**cls.fields_from_json(jobj))
 
 
@@ -457,7 +458,8 @@ def decode_csr(b64der: str) -> josepy.util.ComparableX509:
         raise errors.DeserializationError(error)
 
 
-GenericTypedJSONObjectWithFields = TypeVar('GenericTypedJSONObjectWithFields', bound='TypedJSONObjectWithFields')
+GenericTypedJSONObjectWithFields = TypeVar(
+    'GenericTypedJSONObjectWithFields', bound='TypedJSONObjectWithFields')
 
 
 class TypedJSONObjectWithFields(JSONObjectWithFields):

--- a/src/josepy/json_util.py
+++ b/src/josepy/json_util.py
@@ -9,11 +9,11 @@ The framework presented here is somewhat based on `Go's "json" package`_
 import abc
 import binascii
 import logging
-from typing import Dict, Type, Any, Callable, List, Mapping, Optional, TypeVar
+from typing import Any, Callable, Dict, List, Mapping, Optional, Type, TypeVar
 
 from OpenSSL import crypto
-import josepy.util
 
+import josepy.util
 from josepy import b64, errors, interfaces, util
 
 logger = logging.getLogger(__name__)

--- a/src/josepy/jwa.py
+++ b/src/josepy/jwa.py
@@ -5,20 +5,20 @@ https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40
 """
 import abc
 import logging
-from typing import Dict, Any, Callable
+from collections.abc import Hashable
+from typing import Any, Callable, Dict
 
 import cryptography.exceptions
 from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives import hmac
-from cryptography.hazmat.primitives.asymmetric import padding, ec, rsa
-from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
-from cryptography.hazmat.primitives.asymmetric.utils import encode_dss_signature
+from cryptography.hazmat.primitives import hashes, hmac
+from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
+from cryptography.hazmat.primitives.asymmetric.utils import (
+    decode_dss_signature,
+    encode_dss_signature,
+)
 from cryptography.hazmat.primitives.hashes import HashAlgorithm
 
 from josepy import errors, interfaces, jwk
-
-from collections.abc import Hashable
 
 logger = logging.getLogger(__name__)
 

--- a/src/josepy/jwk.py
+++ b/src/josepy/jwk.py
@@ -307,9 +307,8 @@ class JWKEC(JWK):
             binary = json_util.decode_b64jose(data)
             if len(binary) != valid_length:
                 raise errors.DeserializationError(
-                    'Expected parameter "{name}" to be {valid_lengths} bytes '
-                    'after base64-decoding; got {length} bytes instead'.format(
-                        name=name, valid_lengths=valid_length, length=len(binary))
+                    f'Expected parameter "{name}" to be {valid_length} bytes '
+                    f'after base64-decoding; got {len(binary)} bytes instead'
                 )
             return int.from_bytes(binary, byteorder="big")
         except ValueError:  # invalid literal for long() with base 16
@@ -356,10 +355,15 @@ class JWKEC(JWK):
             params['d'] = private.private_value
         else:
             raise errors.SerializationError(
-                'Supplied key is neither of type EllipticCurvePublicKey nor EllipticCurvePrivateKey')
+                'Supplied key is neither of type EllipticCurvePublicKey '
+                'nor EllipticCurvePrivateKey'
+            )
         params['x'] = public.x
         params['y'] = public.y
-        params = {key: self._encode_param(value, self.expected_length_for_curve(public.curve)) for key, value in params.items()}
+        params = {
+            key: self._encode_param(value, self.expected_length_for_curve(public.curve))
+            for key, value in params.items()
+        }
         params['crv'] = self._curve_name_to_crv(public.curve.name)
         return params
 
@@ -377,8 +381,7 @@ class JWKEC(JWK):
 
         # private key
         d = cls._decode_param(jobj['d'], 'd', expected_length)
-        key = ec.EllipticCurvePrivateNumbers(d, public_numbers).private_key(
-            default_backend())
+        key = ec.EllipticCurvePrivateNumbers(d, public_numbers).private_key(default_backend())
         return cls(key=key)
 
     def public_key(self) -> 'JWKEC':

--- a/src/josepy/jwk.py
+++ b/src/josepy/jwk.py
@@ -3,17 +3,24 @@ import abc
 import json
 import logging
 import math
-
-from typing import Dict, Optional, Sequence, Type, Union, Callable, Any, Tuple, Mapping
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+)
 
 import cryptography.exceptions
-import josepy.util
 from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import ec
-from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
 
+import josepy.util
 from josepy import errors, json_util, util
 
 logger = logging.getLogger(__name__)

--- a/src/josepy/jws.py
+++ b/src/josepy/jws.py
@@ -2,7 +2,7 @@
 import argparse
 import base64
 import sys
-from typing import (  # NOQA
+from typing import (
     Any,
     Dict,
     FrozenSet,

--- a/src/josepy/jws.py
+++ b/src/josepy/jws.py
@@ -339,7 +339,7 @@ class JWS(json_util.JSONObjectWithFields):
             signature=b64.b64decode(signature))
         return cls(payload=b64.b64decode(payload), signatures=(sig,))
 
-    def to_partial_json(self, flat: bool = True) -> Dict[str, Any]:  # pylint: disable=arguments-differ
+    def to_partial_json(self, flat: bool = True) -> Dict[str, Any]:
         assert self.signatures
         payload = json_util.encode_b64jose(self.payload)
 

--- a/src/josepy/jws.py
+++ b/src/josepy/jws.py
@@ -2,12 +2,24 @@
 import argparse
 import base64
 import sys
-from typing import Dict, Any, Optional, FrozenSet, Mapping, List, Type, Tuple, cast
+from typing import (  # NOQA
+    Any,
+    Dict,
+    FrozenSet,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+    Type,
+    cast,
+)
 
 from OpenSSL import crypto
 
 import josepy
-from josepy import b64, errors, json_util, jwa, jwk as jwk_mod, util
+from josepy import b64, errors, json_util, jwa
+from josepy import jwk as jwk_mod
+from josepy import util
 
 
 class MediaType:

--- a/src/josepy/magic_typing.py
+++ b/src/josepy/magic_typing.py
@@ -4,7 +4,6 @@ import sys
 import warnings
 from typing import Any
 
-
 warnings.warn("josepy.magic_typing is deprecated and will be removed in a future release.",
               DeprecationWarning)
 

--- a/src/josepy/util.py
+++ b/src/josepy/util.py
@@ -1,13 +1,13 @@
 """JOSE utilities."""
 import abc
-from types import ModuleType
-from typing import Union, Any, Callable, Iterator, Tuple, List, TypeVar, cast
-from collections.abc import Hashable, Mapping
 import sys
 import warnings
+from collections.abc import Hashable, Mapping
+from types import ModuleType
+from typing import Any, Callable, Iterator, List, Tuple, TypeVar, Union, cast
 
-from OpenSSL import crypto
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from OpenSSL import crypto
 
 
 # Deprecated. Please use built-in decorators @classmethod and abc.abstractmethod together instead.

--- a/tests/b64_test.py
+++ b/tests/b64_test.py
@@ -1,7 +1,6 @@
 """Tests for josepy.b64."""
 import unittest
 
-
 # https://en.wikipedia.org/wiki/Base64#Examples
 B64_PADDING_EXAMPLES = {
     b'any carnal pleasure.': (b'YW55IGNhcm5hbCBwbGVhc3VyZS4', b'='),

--- a/tests/json_util_test.py
+++ b/tests/json_util_test.py
@@ -3,8 +3,9 @@ import itertools
 import unittest
 from unittest import mock
 
-from josepy import errors, interfaces, util
 import test_util
+
+from josepy import errors, interfaces, util
 
 CERT = test_util.load_comparable_cert('cert.pem')
 CSR = test_util.load_comparable_csr('csr.pem')
@@ -14,7 +15,7 @@ class FieldTest(unittest.TestCase):
     """Tests for josepy.json_util.field and josepy.json_util.Field."""
 
     def test_field_function(self):
-        from josepy.json_util import field, Field
+        from josepy.json_util import Field, field
 
         test = field("foo", default="bar")
         self.assertIsInstance(test, Field)
@@ -22,7 +23,7 @@ class FieldTest(unittest.TestCase):
         self.assertEqual(test.default, "bar")
 
     def test_type_field_control(self):
-        from josepy.json_util import field, JSONObjectWithFields
+        from josepy.json_util import JSONObjectWithFields, field
 
         class DummyProperlyTyped(JSONObjectWithFields):
             type: str = field('type')
@@ -102,8 +103,7 @@ class JSONObjectWithFieldsMetaTest(unittest.TestCase):
     """Tests for josepy.json_util.JSONObjectWithFieldsMeta."""
 
     def setUp(self):
-        from josepy.json_util import Field
-        from josepy.json_util import JSONObjectWithFieldsMeta
+        from josepy.json_util import Field, JSONObjectWithFieldsMeta
         self.field = Field('Baz')
         self.field2 = Field('Baz2')
         # pylint: disable=invalid-name,missing-docstring,too-few-public-methods
@@ -147,8 +147,7 @@ class JSONObjectWithFieldsTest(unittest.TestCase):
     # pylint: disable=protected-access
 
     def setUp(self):
-        from josepy.json_util import JSONObjectWithFields
-        from josepy.json_util import Field
+        from josepy.json_util import Field, JSONObjectWithFields
 
         class MockJSONObjectWithFields(JSONObjectWithFields):
             # pylint: disable=invalid-name,missing-docstring,no-self-argument

--- a/tests/jwa_test.py
+++ b/tests/jwa_test.py
@@ -173,9 +173,12 @@ class JWAECTest(unittest.TestCase):
         from josepy.jwk import JWK
         key = JWK.from_json(
             {
-                'd': 'Af9KP6DqLRbtit6NS_LRIaCP_-NdC5l5R2ugbILdfpv6dS9R4wUPNxiGw-vVWumA56Yo1oBnEm8ZdR4W-u1lPHw5',
-                'x': 'AD4i4STyJ07iZJkHkpKEOuICpn6IHknzwAlrf-1w1a5dqOsRe30EECSN4vFxaeAmtdBSCKBwCq7h1q4bPgMrMUvF',
-                'y': 'AHAlXxrabjcx_yBxGObnm_DkEQMJK1E69OHY3x3VxF5VXoKc93CG4GLoaPvphZQvZnt5EfExQoPktwOMIVhBHaFR',
+                'd': 'Af9KP6DqLRbtit6NS_LRIaCP_-NdC5l5R2ugbILdfpv6dS9R4wUPNxiGw'
+                     '-vVWumA56Yo1oBnEm8ZdR4W-u1lPHw5',
+                'x': 'AD4i4STyJ07iZJkHkpKEOuICpn6IHknzwAlrf-1w1a5dqOsRe30EECSN4vFxae'
+                     'AmtdBSCKBwCq7h1q4bPgMrMUvF',
+                'y': 'AHAlXxrabjcx_yBxGObnm_DkEQMJK1E69OHY3x3VxF5VXoKc93CG4GLoaPvphZQv'
+                     'Znt5EfExQoPktwOMIVhBHaFR',
                 'crv': 'P-521',
                 'kty': 'EC'
             })

--- a/tests/jwa_test.py
+++ b/tests/jwa_test.py
@@ -2,8 +2,9 @@
 import unittest
 from unittest import mock
 
-from josepy import errors
 import test_util
+
+from josepy import errors
 
 RSA256_KEY = test_util.load_rsa_private_key('rsa256_key.pem')
 RSA512_KEY = test_util.load_rsa_private_key('rsa512_key.pem')
@@ -50,8 +51,7 @@ class JWASignatureTest(unittest.TestCase):
         self.assertEqual(self.Sig2.to_partial_json(), 'Sig2')
 
     def test_from_json(self):
-        from josepy.jwa import JWASignature
-        from josepy.jwa import RS256
+        from josepy.jwa import RS256, JWASignature
         self.assertIs(JWASignature.from_json('RS256'), RS256)
 
 
@@ -75,8 +75,7 @@ class JWARSTest(unittest.TestCase):
         self.assertRaises(errors.Error, RS256.sign, RSA512_KEY.public_key(), b'foo')
 
     def test_sign_key_too_small(self):
-        from josepy.jwa import RS256
-        from josepy.jwa import PS256
+        from josepy.jwa import PS256, RS256
         self.assertRaises(errors.Error, RS256.sign, RSA256_KEY, b'foo')
         self.assertRaises(errors.Error, PS256.sign, RSA256_KEY, b'foo')
 
@@ -139,9 +138,10 @@ class JWAECTest(unittest.TestCase):
         self.assertIs(ES384.verify(EC_P384_KEY.public_key(), message, signature), False)
 
     def test_verify_with_different_key(self):
-        from josepy.jwa import ES256
-        from cryptography.hazmat.primitives.asymmetric import ec
         from cryptography.hazmat.backends import default_backend
+        from cryptography.hazmat.primitives.asymmetric import ec
+
+        from josepy.jwa import ES256
 
         message = b'foo'
         signature = ES256.sign(EC_P256_KEY, message)
@@ -149,8 +149,9 @@ class JWAECTest(unittest.TestCase):
         self.assertIs(ES256.verify(different_key.public_key(), message, signature), False)
 
     def test_sign_new_api(self):
-        from josepy.jwa import ES256
         from cryptography.hazmat.primitives.asymmetric.ec import SECP256R1
+
+        from josepy.jwa import ES256
         key = mock.MagicMock(curve=SECP256R1())
         with mock.patch("josepy.jwa.decode_dss_signature") as decode_patch:
             decode_patch.return_value = (0, 0)
@@ -159,8 +160,10 @@ class JWAECTest(unittest.TestCase):
 
     def test_verify_new_api(self):
         import math
-        from josepy.jwa import ES256
+
         from cryptography.hazmat.primitives.asymmetric.ec import SECP256R1
+
+        from josepy.jwa import ES256
         key = mock.MagicMock(key_size=256, curve=SECP256R1())
         ES256.verify(key, "message", b'\x00' * math.ceil(key.key_size / 8) * 2)
         self.assertIs(key.verify.called, True)

--- a/tests/jwk_test.py
+++ b/tests/jwk_test.py
@@ -181,7 +181,7 @@ class JWKRSATest(unittest.TestCase, JWKTestBaseMixin):
     "use": "sig",
     "n": "n4EPtAOCc9AlkeQHPzHStgAbgs7bTZLwUBZdR8_KuKPEHLd4rHVTeT-O-XV2jRojdNhxJWTDvNd7nqQ0VEiZQHz_AJmSCpMaJMRBSFKrKb2wqVwGU_NsYOYL-QtiWN2lbzcEe6XC0dApr5ydQLrHqkHHig3RBordaZ6Aj-oBHqFEHYpPe7Tpe-OfVfHd1E6cS6M1FZcD1NNLYD5lFHpPI9bTwJlsde3uhGqC0ZCuEHg8lhzwOHrtIQbS0FVbb9k3-tVTU4fg_3L_vniUFAKwuCLqKnS2BYwdq_mzSnbLY7h_qixoR7jig3__kRhuaxwUkRz5iaiQkqgc5gHdrNP5zw",
     "e": "AQAB"
-}""")
+}""")  # noqa
         self.assertEqual(
             binascii.hexlify(key.thumbprint()),
             b"f63838e96077ad1fc01c3f8405774dedc0641f558ebb4b40dccf5f9b6d66a932")
@@ -215,8 +215,8 @@ class JWKECTest(unittest.TestCase, JWKTestBaseMixin):
         self.jwk521json = {
             'kty': 'EC',
             'crv': 'P-521',
-            'x': 'AFkdl6cKzBmP18U8fffpP4IZN2eED45hDcwRPl5ZeClwHcLtnMBMuWYFFO_Nzm6DL2MhpN0zI2bcMLJd95aY2tPs',
-            'y': 'AYvZq3wByjt7nQd8nYMqhFNCL3j_-U6GPWZet1hYBY_XZHrC4yIV0R4JnssRAY9eqc1EElpCc4hziis1jiV1iR4W',
+            'x': 'AFkdl6cKzBmP18U8fffpP4IZN2eED45hDcwRPl5ZeClwHcLtnMBMuWYFFO_Nzm6DL2MhpN0zI2bcMLJd95aY2tPs',  # noqa
+            'y': 'AYvZq3wByjt7nQd8nYMqhFNCL3j_-U6GPWZet1hYBY_XZHrC4yIV0R4JnssRAY9eqc1EElpCc4hziis1jiV1iR4W',  # noqa
         }
         self.private = JWKEC(key=EC_P256_KEY)
         self.private_json = {
@@ -297,8 +297,15 @@ class JWKECTest(unittest.TestCase, JWKTestBaseMixin):
         self.assertRaises(errors.DeserializationError, JWK.from_json,
                           {'kty': 'EC', 'crv': 'P-256', 'x': 'AQAB',
                            'y': 'm2Fylv-Uz7trgTW8EBHP3FQSMeZs2GNQ6VRo1sIVJEk'})
-        self.assertRaises(errors.DeserializationError, JWK.from_json,
-                          {'kty': 'EC', 'crv': 'P-256', 'x': 'jjQtV-fA7J_tK8dPzYq7jRPNjF8r5p6LW2R25S2Gw5U', 'y': '1'})
+        self.assertRaises(
+            errors.DeserializationError, JWK.from_json,
+            {
+                'kty': 'EC',
+                'crv': 'P-256',
+                'x': 'jjQtV-fA7J_tK8dPzYq7jRPNjF8r5p6LW2R25S2Gw5U',
+                'y': '1',
+            }
+        )
 
     def test_unknown_crv_name(self):
         from josepy.jwk import JWK

--- a/tests/jwk_test.py
+++ b/tests/jwk_test.py
@@ -2,8 +2,9 @@
 import binascii
 import unittest
 
-from josepy import errors, json_util, util
 import test_util
+
+from josepy import errors, json_util, util
 
 DSA_PEM = test_util.load_vector('dsa512_key.pem')
 RSA256_KEY = test_util.load_rsa_private_key('rsa256_key.pem')
@@ -114,6 +115,7 @@ class JWKRSATest(unittest.TestCase, JWKTestBaseMixin):
 
     def test_encode_param_zero(self):
         from josepy.jwk import JWKRSA
+
         # pylint: disable=protected-access
         # TODO: move encode/decode _param to separate class
         self.assertEqual('AA', JWKRSA._encode_param(0))
@@ -232,6 +234,7 @@ class JWKECTest(unittest.TestCase, JWKTestBaseMixin):
 
     def test_encode_param_zero(self):
         from josepy.jwk import JWKEC
+
         # pylint: disable=protected-access
         # TODO: move encode/decode _param to separate class
         self.assertEqual('AA', JWKEC._encode_param(0, 1))
@@ -306,8 +309,8 @@ class JWKECTest(unittest.TestCase, JWKTestBaseMixin):
                            'y': 'EPAw8_8z7PYKsHH6hlGSlsWxFoFl7-0vM0QRGbmnvCc'})
 
     def test_encode_y_leading_zero_p256(self):
-        from josepy.jwk import JWKEC, JWK
         import josepy
+        from josepy.jwk import JWK, JWKEC
         data = b"""-----BEGIN EC PRIVATE KEY-----
 MHcCAQEEICZ7LCI99Na2KZ/Fq8JmJROakGJ5+J7rHiGSPoO36kOAoAoGCCqGSM49
 AwEHoUQDQgAEGS5RvStca15z2FEanCM3juoX7tE/LB7iD44GWawGE40APAl/iZuH

--- a/tests/jws_test.py
+++ b/tests/jws_test.py
@@ -4,9 +4,9 @@ import unittest
 from unittest import mock
 
 import OpenSSL
+import test_util
 
 from josepy import errors, json_util, jwa, jwk
-import test_util
 
 CERT = test_util.load_comparable_cert('cert.pem')
 KEY = jwk.JWKRSA.load(test_util.load_vector('rsa512_key.pem'))
@@ -81,8 +81,7 @@ class SignatureTest(unittest.TestCase):
     """Tests for josepy.jws.Signature."""
 
     def test_from_json(self):
-        from josepy.jws import Header
-        from josepy.jws import Signature
+        from josepy.jws import Header, Signature
         self.assertEqual(
             Signature(signature=b'foo', header=Header(alg=jwa.RS256)),
             Signature.from_json(

--- a/tests/jws_test.py
+++ b/tests/jws_test.py
@@ -19,14 +19,12 @@ class MediaTypeTest(unittest.TestCase):
         from josepy.jws import MediaType
         self.assertEqual('application/app', MediaType.decode('application/app'))
         self.assertEqual('application/app', MediaType.decode('app'))
-        self.assertRaises(
-            errors.DeserializationError, MediaType.decode, 'app;foo')
+        self.assertRaises(errors.DeserializationError, MediaType.decode, 'app;foo')
 
     def test_encode(self):
         from josepy.jws import MediaType
         self.assertEqual('app', MediaType.encode('application/app'))
-        self.assertEqual('application/app;foo',
-                         MediaType.encode('application/app;foo'))
+        self.assertEqual('application/app;foo', MediaType.encode('application/app;foo'))
 
 
 class HeaderTest(unittest.TestCase):

--- a/tests/magic_typing_test.py
+++ b/tests/magic_typing_test.py
@@ -20,7 +20,7 @@ class MagicTypingTest(unittest.TestCase):
             del sys.modules['josepy.magic_typing']  # pragma: no cover
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=DeprecationWarning)
-            from josepy.magic_typing import Text  # pylint: disable=no-name-in-module
+            from josepy.magic_typing import Text
         self.assertEqual(Text, text_mock)
         del sys.modules['josepy.magic_typing']
         sys.modules['typing'] = temp_typing

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,12 +2,12 @@
 import os
 from typing import Any
 
-import josepy.util
-from OpenSSL import crypto
 import pkg_resources
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
+from OpenSSL import crypto
 
+import josepy.util
 from josepy import ComparableRSAKey, ComparableX509
 from josepy.util import ComparableECKey
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -21,8 +21,7 @@ def vector_path(*names: str) -> str:
 def load_vector(*names: str) -> bytes:
     """Load contents of a test vector."""
     # luckily, resource_string opens file in binary mode
-    return pkg_resources.resource_string(
-        __name__, os.path.join('testdata', *names))
+    return pkg_resources.resource_string(__name__, os.path.join('testdata', *names))
 
 
 def _guess_loader(filename: str, loader_pem: Any, loader_der: Any) -> Any:

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -216,6 +216,7 @@ class frozendictTest(unittest.TestCase):  # pylint: disable=invalid-name
 
     def test_init_other_raises_type_error(self):
         from josepy.util import frozendict
+
         # specifically fail for generators...
         self.assertRaises(TypeError, frozendict, {'a': 'b'}.items())
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ commands =
 
 [testenv:isort]
 commands =
-    isort --check src tests
+    isort --check --diff src tests
 
 [testenv:mypy]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,13 @@ deps =
     -cconstraints.txt
     -e .[tests]
 
-[flake8]
-ignore = W504, E501
+[testenv:flake8]
+commands =
+    flake8 src tests
+
+[testenv:isort]
+commands =
+    isort --check src tests
 
 [testenv:mypy]
 commands =


### PR DESCRIPTION
I think it'd make sense to activate `flake8` as well as introducing a standardized way of importing things.

There are still various comments relating to how pylint should work, but it doesn't seem to be used. Maybe those could be deleted/evaluated at some point. 

`E501` (maximum line length) should also be fixed. There aren't many places where it's wrong.  