### PR TITLE
Remove # pylint markers.

### DIFF
--- a/src/josepy/interfaces.py
+++ b/src/josepy/interfaces.py
@@ -6,14 +6,10 @@ from typing import Any, Type, TypeVar, Union
 
 from josepy import errors
 
-# pylint: disable=no-self-argument,no-method-argument,no-init,inherit-non-class
-# pylint: disable=too-few-public-methods
-
 GenericJSONDeSerializable = TypeVar("GenericJSONDeSerializable", bound="JSONDeSerializable")
 
 
-class JSONDeSerializable(object, metaclass=abc.ABCMeta):
-    # pylint: disable=too-few-public-methods
+class JSONDeSerializable(metaclass=abc.ABCMeta):
     """Interface for (de)serializable JSON objects.
 
     Please recall, that standard Python library implements
@@ -168,7 +164,7 @@ class JSONDeSerializable(object, metaclass=abc.ABCMeta):
         """
         # TypeError: Can't instantiate abstract class <cls> with
         # abstract methods from_json, to_partial_json
-        return cls()  # pylint: disable=abstract-class-instantiated
+        return cls()
 
     @classmethod
     def json_loads(cls: Type[GenericJSONDeSerializable],

--- a/src/josepy/json_util.py
+++ b/src/josepy/json_util.py
@@ -66,7 +66,6 @@ class Field:
     def __init__(self, json_name: str, default: Any = None, omitempty: bool = False,
                  decoder: Callable[[Any], Any] = None,
                  encoder: Callable[[Any], Any] = None) -> None:
-        # pylint: disable=too-many-arguments
         self.json_name = json_name
         self.default = default
         self.omitempty = omitempty
@@ -97,7 +96,7 @@ class Field:
             "encoder": self.fenc,
             **kwargs,
         }
-        return type(self)(**current)  # type: ignore[arg-type]  # pylint: disable=star-args
+        return type(self)(**current)  # type: ignore[arg-type]
 
     def decoder(self, fdec: Callable[[Any], Any]) -> 'Field':
         """Descriptor to change the decoder on JSON object field."""
@@ -225,7 +224,6 @@ GenericJSONObjectWithFields = TypeVar('GenericJSONObjectWithFields', bound='JSON
 class JSONObjectWithFields(util.ImmutableMap,
                            interfaces.JSONDeSerializable,
                            metaclass=JSONObjectWithFieldsMeta):
-    # pylint: disable=too-few-public-methods
     """JSON object with fields.
 
     Example::
@@ -259,9 +257,7 @@ class JSONObjectWithFields(util.ImmutableMap,
         }
 
     def __init__(self, **kwargs: Any) -> None:
-        # pylint: disable=star-args
-        super().__init__(
-            **{**self._defaults(), **kwargs})
+        super().__init__(**{**self._defaults(), **kwargs})
 
     def encode(self, name: str) -> Any:
         """Encode a single field.

--- a/src/josepy/jwa.py
+++ b/src/josepy/jwa.py
@@ -23,8 +23,7 @@ from josepy import errors, interfaces, jwk
 logger = logging.getLogger(__name__)
 
 
-class JWA(interfaces.JSONDeSerializable):  # pylint: disable=abstract-method
-    # pylint: disable=too-few-public-methods
+class JWA(interfaces.JSONDeSerializable):
     # for some reason disable=abstract-method has to be on the line
     # above...
     """JSON Web Algorithm."""

--- a/src/josepy/jwk.py
+++ b/src/josepy/jwk.py
@@ -27,7 +27,6 @@ logger = logging.getLogger(__name__)
 
 
 class JWK(json_util.TypedJSONObjectWithFields, metaclass=abc.ABCMeta):
-    # pylint: disable=too-few-public-methods
     """JSON Web Key."""
     type_field_name = 'kty'
     TYPES: Dict[str, Type['JWK']] = {}
@@ -204,7 +203,6 @@ class JWKRSA(JWK):
 
     @classmethod
     def fields_from_json(cls, jobj: Mapping[str, Any]) -> 'JWKRSA':
-        # pylint: disable=invalid-name
         n, e = (cls._decode_param(jobj[x]) for x in ('n', 'e'))
         public_numbers = rsa.RSAPublicNumbers(e=e, n=n)
 
@@ -245,7 +243,6 @@ class JWKRSA(JWK):
         return cls(key=key)
 
     def fields_to_partial_json(self) -> Dict[str, Any]:
-        # pylint: disable=protected-access
         if isinstance(self.key._wrapped, rsa.RSAPublicKey):
             numbers = self.key.public_numbers()
             params = {
@@ -369,7 +366,6 @@ class JWKEC(JWK):
 
     @classmethod
     def fields_from_json(cls, jobj: Mapping[str, Any]) -> 'JWKEC':
-        # pylint: disable=invalid-name
         curve = cls._crv_to_curve(jobj['crv'])
         expected_length = cls.expected_length_for_curve(curve)
         x, y = (cls._decode_param(jobj[n], n, expected_length) for n in ('x', 'y'))

--- a/src/josepy/jws.py
+++ b/src/josepy/jws.py
@@ -106,7 +106,7 @@ class Header(json_util.JSONObjectWithFields):
             raise TypeError('Addition of overlapping headers not defined')
 
         not_omitted_self.update(not_omitted_other)
-        return type(self)(**not_omitted_self)  # pylint: disable=star-args
+        return type(self)(**not_omitted_self)
 
     def find_key(self) -> josepy.JWK:
         """Find key based on header.
@@ -125,19 +125,18 @@ class Header(json_util.JSONObjectWithFields):
 
     @crit.decoder  # type: ignore
     def crit(unused_value: Any) -> Any:
-        # pylint: disable=missing-docstring,no-self-argument,no-self-use
         raise errors.DeserializationError(
             '"crit" is not supported, please subclass')
 
     # x5c does NOT use JOSE Base64 (4.1.6)
 
     @x5c.encoder  # type: ignore
-    def x5c(value):  # pylint: disable=missing-docstring,no-self-argument
+    def x5c(value):
         return [base64.b64encode(crypto.dump_certificate(
             crypto.FILETYPE_ASN1, cert.wrapped)) for cert in value]
 
     @x5c.decoder  # type: ignore
-    def x5c(value):  # pylint: disable=missing-docstring,no-self-argument
+    def x5c(value):
         try:
             return tuple(util.ComparableX509(crypto.load_certificate(
                 crypto.FILETYPE_ASN1,
@@ -169,12 +168,12 @@ class Signature(json_util.JSONObjectWithFields):
         encoder=json_util.encode_b64jose)
 
     @protected.encoder  # type: ignore
-    def protected(value: str) -> str:  # pylint: disable=missing-docstring,no-self-argument
+    def protected(value: str) -> str:
         # wrong type guess (Signature, not bytes) | pylint: disable=no-member
         return json_util.encode_b64jose(value.encode('utf-8'))
 
     @protected.decoder  # type: ignore
-    def protected(value: str) -> str:  # pylint: disable=missing-docstring,no-self-argument
+    def protected(value: str) -> str:
         return json_util.decode_b64jose(value).decode('utf-8')
 
     def __init__(self, **kwargs: Any) -> None:
@@ -244,12 +243,11 @@ class Signature(json_util.JSONObjectWithFields):
             if header in header_params:
                 protected_params[header] = header_params.pop(header)
         if protected_params:
-            # pylint: disable=star-args
             protected = cls.header_cls(**protected_params).json_dumps()
         else:
             protected = ''
 
-        header = cls.header_cls(**header_params)  # pylint: disable=star-args
+        header = cls.header_cls(**header_params)
         signature = alg.sign(key.key, cls._msg(protected, payload))
 
         return cls(protected=protected, header=header, signature=signature)

--- a/src/josepy/util.py
+++ b/src/josepy/util.py
@@ -15,7 +15,7 @@ def abstractclassmethod(func: Callable) -> classmethod:
     return classmethod(abc.abstractmethod(func))
 
 
-class ComparableX509:  # pylint: disable=too-few-public-methods
+class ComparableX509:
     """Wrapper for OpenSSL.crypto.X509** objects that supports __eq__.
 
     :ivar wrapped: Wrapped certificate or certificate request.
@@ -52,7 +52,6 @@ class ComparableX509:  # pylint: disable=too-few-public-methods
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, self.__class__):
             return NotImplemented
-        # pylint: disable=protected-access
         return self._dump() == other._dump()
 
     def __hash__(self) -> int:
@@ -62,7 +61,7 @@ class ComparableX509:  # pylint: disable=too-few-public-methods
         return '<{0}({1!r})>'.format(self.__class__.__name__, self.wrapped)
 
 
-class ComparableKey:  # pylint: disable=too-few-public-methods
+class ComparableKey:
     """Comparable wrapper for ``cryptography`` keys.
 
     See https://github.com/pyca/cryptography/issues/2122.
@@ -82,7 +81,6 @@ class ComparableKey:  # pylint: disable=too-few-public-methods
         return getattr(self._wrapped, name)
 
     def __eq__(self, other: Any) -> bool:
-        # pylint: disable=protected-access
         if (not isinstance(other, self.__class__) or
                 self._wrapped.__class__ is not other._wrapped.__class__):
             return NotImplemented
@@ -105,7 +103,7 @@ class ComparableKey:  # pylint: disable=too-few-public-methods
         return self.__class__(self._wrapped.public_key())
 
 
-class ComparableRSAKey(ComparableKey):  # pylint: disable=too-few-public-methods
+class ComparableRSAKey(ComparableKey):
     """Wrapper for ``cryptography`` RSA keys.
 
     Wraps around:
@@ -130,7 +128,7 @@ class ComparableRSAKey(ComparableKey):  # pylint: disable=too-few-public-methods
         raise NotImplementedError()
 
 
-class ComparableECKey(ComparableKey):  # pylint: disable=too-few-public-methods
+class ComparableECKey(ComparableKey):
     """Wrapper for ``cryptography`` RSA keys.
     Wraps around:
     - :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePrivateKey`
@@ -155,7 +153,6 @@ GenericImmutableMap = TypeVar('GenericImmutableMap', bound='ImmutableMap')
 
 
 class ImmutableMap(Mapping, Hashable):
-    # pylint: disable=too-few-public-methods
     """Immutable key to value mapping with attribute access."""
 
     __slots__: Tuple[str, ...] = ()
@@ -173,7 +170,7 @@ class ImmutableMap(Mapping, Hashable):
     def update(self: GenericImmutableMap, **kwargs: Any) -> GenericImmutableMap:
         """Return updated map."""
         items: Mapping[str, Any] = {**self, **kwargs}
-        return type(self)(**items)  # pylint: disable=star-args
+        return type(self)(**items)
 
     def __getitem__(self, key: str) -> Any:
         try:
@@ -200,7 +197,6 @@ class ImmutableMap(Mapping, Hashable):
 
 
 class frozendict(Mapping, Hashable):
-    # pylint: disable=invalid-name,too-few-public-methods
     """Frozen dictionary."""
     __slots__ = ('_items', '_keys')
 

--- a/tests/interfaces_test.py
+++ b/tests/interfaces_test.py
@@ -3,12 +3,9 @@ import unittest
 
 
 class JSONDeSerializableTest(unittest.TestCase):
-    # pylint: disable=too-many-instance-attributes
 
     def setUp(self):
         from josepy.interfaces import JSONDeSerializable
-
-        # pylint: disable=missing-docstring,invalid-name
 
         class Basic(JSONDeSerializable):
             def __init__(self, v):
@@ -53,7 +50,6 @@ class JSONDeSerializableTest(unittest.TestCase):
         self.nested = Basic([[self.basic1]])
         self.tuple = Basic(('foo',))
 
-        # pylint: disable=invalid-name
         self.Basic = Basic
         self.Sequence = Sequence
         self.Mapping = Mapping

--- a/tests/json_util_test.py
+++ b/tests/json_util_test.py
@@ -44,8 +44,6 @@ class FieldTest(unittest.TestCase):
     def test_descriptors(self):
         mock_value = mock.MagicMock()
 
-        # pylint: disable=missing-docstring
-
         def decoder(unused_value):
             return 'd'
 
@@ -64,7 +62,6 @@ class FieldTest(unittest.TestCase):
 
     def test_default_encoder_is_partial(self):
         class MockField(interfaces.JSONDeSerializable):
-            # pylint: disable=missing-docstring
             def to_partial_json(self):
                 return 'foo'  # pragma: no cover
 
@@ -106,10 +103,8 @@ class JSONObjectWithFieldsMetaTest(unittest.TestCase):
         from josepy.json_util import Field, JSONObjectWithFieldsMeta
         self.field = Field('Baz')
         self.field2 = Field('Baz2')
-        # pylint: disable=invalid-name,missing-docstring,too-few-public-methods
-        # pylint: disable=blacklisted-name
 
-        class A(object, metaclass=JSONObjectWithFieldsMeta):
+        class A(metaclass=JSONObjectWithFieldsMeta):
             __slots__ = ('bar',)
             baz = self.field
 
@@ -124,12 +119,10 @@ class JSONObjectWithFieldsMetaTest(unittest.TestCase):
         self.c_cls = C
 
     def test_fields(self):
-        # pylint: disable=protected-access,no-member
         self.assertEqual({'baz': self.field}, self.a_cls._fields)
         self.assertEqual({'baz': self.field}, self.b_cls._fields)
 
     def test_fields_inheritance(self):
-        # pylint: disable=protected-access,no-member
         self.assertEqual({'baz': self.field2}, self.c_cls._fields)
 
     def test_slots(self):
@@ -137,21 +130,17 @@ class JSONObjectWithFieldsMetaTest(unittest.TestCase):
         self.assertEqual(('baz',), self.b_cls.__slots__)
 
     def test_orig_slots(self):
-        # pylint: disable=protected-access,no-member
         self.assertEqual(('bar',), self.a_cls._orig_slots)
         self.assertEqual((), self.b_cls._orig_slots)
 
 
 class JSONObjectWithFieldsTest(unittest.TestCase):
     """Tests for josepy.json_util.JSONObjectWithFields."""
-    # pylint: disable=protected-access
 
     def setUp(self):
         from josepy.json_util import Field, JSONObjectWithFields
 
         class MockJSONObjectWithFields(JSONObjectWithFields):
-            # pylint: disable=invalid-name,missing-docstring,no-self-argument
-            # pylint: disable=too-few-public-methods
             x = Field('x', omitempty=True,
                       encoder=(lambda x: x * 2),
                       decoder=(lambda x: x / 2))
@@ -170,7 +159,6 @@ class JSONObjectWithFieldsTest(unittest.TestCase):
                     raise errors.DeserializationError()
                 return value
 
-        # pylint: disable=invalid-name
         self.MockJSONObjectWithFields = MockJSONObjectWithFields
         self.mock = MockJSONObjectWithFields(x=None, y=2, z=3)
 
@@ -341,9 +329,6 @@ class TypedJSONObjectWithFieldsTest(unittest.TestCase):
 
     def setUp(self):
         from josepy.json_util import TypedJSONObjectWithFields
-
-        # pylint: disable=missing-docstring,abstract-method
-        # pylint: disable=too-few-public-methods
 
         class MockParentTypedJSONObjectWithFields(TypedJSONObjectWithFields):
             TYPES = {}

--- a/tests/jwa_test.py
+++ b/tests/jwa_test.py
@@ -21,15 +21,12 @@ class JWASignatureTest(unittest.TestCase):
         from josepy.jwa import JWASignature
 
         class MockSig(JWASignature):
-            # pylint: disable=missing-docstring,too-few-public-methods
-            # pylint: disable=abstract-class-not-used
             def sign(self, key, msg):
                 raise NotImplementedError()  # pragma: no cover
 
             def verify(self, key, msg, sig):
                 raise NotImplementedError()  # pragma: no cover
 
-        # pylint: disable=invalid-name
         self.Sig1 = MockSig('Sig1')
         self.Sig2 = MockSig('Sig2')
 
@@ -55,7 +52,7 @@ class JWASignatureTest(unittest.TestCase):
         self.assertIs(JWASignature.from_json('RS256'), RS256)
 
 
-class JWAHSTest(unittest.TestCase):  # pylint: disable=too-few-public-methods
+class JWAHSTest(unittest.TestCase):
 
     def test_it(self):
         from josepy.jwa import HS256

--- a/tests/jwk_test.py
+++ b/tests/jwk_test.py
@@ -71,7 +71,6 @@ class JWKOctTest(unittest.TestCase, JWKTestBaseMixin):
 
 class JWKRSATest(unittest.TestCase, JWKTestBaseMixin):
     """Tests for josepy.jwk.JWKRSA."""
-    # pylint: disable=too-many-instance-attributes
 
     thumbprint = (b'\x83K\xdc#3\x98\xca\x98\xed\xcb\x80\x80<\x0c'
                   b'\xf0\x95\xb9H\xb2*l\xbd$\xe5&|O\x91\xd4 \xb0Y')
@@ -84,9 +83,7 @@ class JWKRSATest(unittest.TestCase, JWKTestBaseMixin):
             'e': 'AQAB',
             'n': 'm2Fylv-Uz7trgTW8EBHP3FQSMeZs2GNQ6VRo1sIVJEk',
         }
-        # pylint: disable=protected-access
-        self.jwk256_not_comparable = JWKRSA(
-            key=RSA256_KEY.public_key()._wrapped)
+        self.jwk256_not_comparable = JWKRSA(key=RSA256_KEY.public_key()._wrapped)
         self.jwk512 = JWKRSA(key=RSA512_KEY.public_key())
         self.jwk512json = {
             'kty': 'RSA',
@@ -116,7 +113,6 @@ class JWKRSATest(unittest.TestCase, JWKTestBaseMixin):
     def test_encode_param_zero(self):
         from josepy.jwk import JWKRSA
 
-        # pylint: disable=protected-access
         # TODO: move encode/decode _param to separate class
         self.assertEqual('AA', JWKRSA._encode_param(0))
 

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -68,7 +68,6 @@ class ComparableRSAKeyTest(unittest.TestCase):
         self.assertNotEqual(self.key, 5)
 
     def test_ne_not_wrapped(self):
-        # pylint: disable=protected-access
         self.assertNotEqual(self.key, self.key_same._wrapped)
 
     def test_ne_no_serialization(self):
@@ -113,7 +112,6 @@ class ComparableECKeyTest(unittest.TestCase):
         self.assertNotEqual(self.p256_key, 5)
 
     def test_ne_not_wrapped(self):
-        # pylint: disable=protected-access
         self.assertNotEqual(self.p256_key, self.p256_key_same._wrapped)
 
     def test_ne_no_serialization(self):
@@ -139,8 +137,6 @@ class ImmutableMapTest(unittest.TestCase):
     """Tests for josepy.util.ImmutableMap."""
 
     def setUp(self):
-        # pylint: disable=invalid-name,too-few-public-methods
-        # pylint: disable=missing-docstring
         from josepy.util import ImmutableMap
 
         class A(ImmutableMap):
@@ -203,7 +199,7 @@ class ImmutableMapTest(unittest.TestCase):
         self.assertEqual("B(x='foo', y='bar')", repr(self.B(x='foo', y='bar')))
 
 
-class frozendictTest(unittest.TestCase):  # pylint: disable=invalid-name
+class frozendictTest(unittest.TestCase):
     """Tests for josepy.util.frozendict."""
 
     def setUp(self):


### PR DESCRIPTION
Considering pylint is not really used in the project, perhaps these markers/annotations can be removed.