### PR TITLE
Fix release script

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -135,6 +135,7 @@ pip install -U pip
 pip install \
   --no-cache-dir \
   --extra-index-url http://localhost:$PORT \
+  --constraint ../constraints.txt \
   josepy[tests]
 # stop local PyPI
 kill $!
@@ -150,10 +151,9 @@ fi
 mkdir kgs
 kgs="kgs/$version"
 pip freeze | tee $kgs
-pip install pytest
-echo testing josepy
-pytest --pyargs josepy
 cd ~-
+echo testing josepy
+pytest
 deactivate
 
 git commit --gpg-sign="$RELEASE_GPG_KEY" -m "Release $version"


### PR DESCRIPTION
This PR does two things:

1. It fixes only a subset of our tests running in the release script. More info at https://github.com/certbot/josepy/pull/129#discussion_r806239144.
2. The new major version of `pytest` raises deprecation warnings about `pytest-flake8` which we've configured `pytest` to error on. See https://docs.pytest.org/en/7.0.x/changelog.html#deprecations. This is fixed in https://github.com/certbot/josepy/pull/129, but let's use our constraints file to avoid this problem for now. We use our pinned dependencies in the Certbot release script too since https://github.com/certbot/certbot/pull/6602.