### PR TITLE
Use python3 in the release script

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -112,10 +112,10 @@ poetry export -f requirements.txt --dev --without-hashes > constraints.txt
 echo "Testing packages"
 cd "dist.$version"
 # start local PyPI
-python -m http.server "$PORT" &
+python3 -m http.server "$PORT" &
 # cd .. is NOT done on purpose: we make sure that all subpackages are
 # installed from local PyPI rather than current directory (repo root)
-python -m venv ../venv
+python3 -m venv ../venv
 . ../venv/bin/activate
 pip install -U setuptools
 pip install -U pip


### PR DESCRIPTION
`python` works for me locally because I use `pyenv` and have `python` set to a version of `python3` when I'm working on Certbot stuff. `python` doesn't work without `pyenv` on macOS or Debian based distros. To fix this, `python3` can be used instead.

I did this on the Certbot release script in https://github.com/certbot/certbot/pull/7918.