### PR TITLE
Stop using codecov

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -46,11 +46,6 @@ jobs:
         run:
           tox -e flake8
           tox -e isort
-      # COVERAGE
-      - name: Upload coverage
-        uses: codecov/codecov-action@v2
-        with:
-          fail_ci_if_error: true
   # This job runs our tests like external parties such as packagers.
   external:
     runs-on: ubuntu-latest

--- a/README.rst
+++ b/README.rst
@@ -3,9 +3,6 @@ JOSE protocol implementation in Python using cryptography
 .. image:: https://github.com/certbot/josepy/actions/workflows/check.yaml/badge.svg
   :target: https://github.com/certbot/josepy/actions/workflows/check.yaml
 
-.. image:: https://codecov.io/gh/certbot/josepy/branch/master/graph/badge.svg
-  :target: https://codecov.io/gh/certbot/josepy
-
 .. image:: https://readthedocs.org/projects/josepy/badge/?version=latest
   :target: http://josepy.readthedocs.io/en/latest/?badge=latest
 


### PR DESCRIPTION
[We no longer use it on the main Certbot repo](https://github.com/certbot/certbot/pull/7811) and it's been repeatedly failing for us here recently.