### PR TITLE
Use proper constraints

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ build:
   jobs:
     pre_install:
       - curl -sSL https://install.python-poetry.org | python3 -
-      - ${HOME}/.local/bin/poetry export -f requirements.txt --dev -E docs --without-hashes > constraints.txt
+      - ${HOME}/.local/bin/poetry export -f constraints.txt --dev -E docs --without-hashes > constraints.txt
 
 python:
   install:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ build:
   jobs:
     pre_install:
       - curl -sSL https://install.python-poetry.org | python3 -
-      - ${HOME}/.local/bin/poetry export -f constraints.txt --dev -E docs --without-hashes > constraints.txt
+      - ${HOME}/.local/bin/poetry export -f constraints.txt --with dev -E docs --without-hashes > constraints.txt
 
 python:
   install:

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -12,8 +12,11 @@ if [ "`dirname $0`" != "tools" ] ; then
     exit 1
 fi
 
-if ! poetry --version >> /dev/null 2>&1 ; then
-    echo Please install poetry before running this script
+if ! poetry export --help 2>&1 | grep -q constraints.txt ; then
+    # turn off set -x for saner output
+    set +x
+    echo 'Please install poetry with poetry-plugin-export>=1.1.0'
+    echo 'before running this script.'
     exit 1
 fi
 
@@ -108,7 +111,7 @@ done
 
 mkdir "dist.$version"
 mv dist "dist.$version/josepy"
-poetry export -f requirements.txt --dev --without-hashes > constraints.txt
+poetry export -f constraints.txt --dev --without-hashes > constraints.txt
 
 echo "Testing packages"
 cd "dist.$version"

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -111,7 +111,7 @@ done
 
 mkdir "dist.$version"
 mv dist "dist.$version/josepy"
-poetry export -f constraints.txt --dev --without-hashes > constraints.txt
+poetry export -f constraints.txt --with dev --without-hashes > constraints.txt
 
 echo "Testing packages"
 cd "dist.$version"


### PR DESCRIPTION
Our readthedocs build started failing due to a change in pip. See https://readthedocs.org/projects/josepy/builds/18224913/.

Luckily, Poetry added the ability to export constraint.txt files over the weekend. See https://github.com/python-poetry/poetry-plugin-export/blob/dd3b674d21079af615979eda241385f550e3f4ae/CHANGELOG.md#110---2022-10-01.

I updated things to make use of this and you can see the readthedocs build passing with this change at https://readthedocs.org/projects/josepy/builds/18238149/. I also edited the release script to fail fast if poetry export doesn't have constraints.txt support.

Finally, I switched the poetry export flags `--dev` for `--with dev` as `--dev` is deprecated as described at https://github.com/python-poetry/poetry-plugin-export/tree/dd3b674d21079af615979eda241385f550e3f4ae#available-options and was printing deprecation warnings.