### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -43,7 +43,7 @@ jobs:
         run: tox -e mypy
       # LINTING
       - name: Run flake8 and isort
-        run:
+        run: |
           tox -e flake8
           tox -e isort
   # This job runs our tests like external parties such as packagers.

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ isolated_build = true
 envlist = py3.{7,8,9,10,11},mypy
 
 [testenv]
-whitelist_externals = poetry
+allowlist_externals = poetry
 commands =
     poetry install -v
     poetry run pytest -v --cov-report xml --cov-report=term-missing --cov=josepy {posargs}


### PR DESCRIPTION
[tox changed the name of the option in `tox.ini`](https://tox.wiki/en/latest/changelog.html#deprecations-and-removals-4-0-0rc4) and our [syntax for a multiline command](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun) wasn't quite right and [doesn't work with new versions of tox](https://github.com/certbot/josepy/actions/runs/3657887185/jobs/6181983345#step:8:1).