### PR TITLE
Improve tox and docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,15 +54,15 @@ $ .\.venv\Script\activate
 ## Run the tests and quality checks
 
 1) Configure a development environment ([see above](#configure-a-development-environment))
-2) Run the unit tests
+2) Run the tests
+```bash
+$ tox
+```
+3) You can also run specific tests
 ```bash
 $ tox -e py
 ```
-3) Run the linter and import format checker
+You can get a listing of the available tests by running
 ```bash
-$ tox -e flake8 isort
-```
-4) Run the type checker
-```bash
-$ tox -e mypy
+$ tox -l
 ```

--- a/README.rst
+++ b/README.rst
@@ -10,4 +10,6 @@ Originally developed as part of the ACME_ protocol implementation.
 
 .. _ACME: https://pypi.python.org/pypi/acme
 
-To learn how to contribute to this project, see :doc:`/CONTRIBUTING.md`.
+To learn how to contribute to this project, see CONTRIBUTING_.
+
+.. _CONTRIBUTING: CONTRIBUTING.md

--- a/README.rst
+++ b/README.rst
@@ -10,4 +10,4 @@ Originally developed as part of the ACME_ protocol implementation.
 
 .. _ACME: https://pypi.python.org/pypi/acme
 
-To learn how to contribute to this project, see :doc:`CONTRIBUTING.md`.
+To learn how to contribute to this project, see :doc:`/CONTRIBUTING.md`.

--- a/README.rst
+++ b/README.rst
@@ -9,3 +9,5 @@ JOSE protocol implementation in Python using cryptography
 Originally developed as part of the ACME_ protocol implementation.
 
 .. _ACME: https://pypi.python.org/pypi/acme
+
+To learn how to contribute to this project, see :doc:`CONTRIBUTING.md`.

--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,6 @@ Originally developed as part of the ACME_ protocol implementation.
 
 .. _ACME: https://pypi.python.org/pypi/acme
 
-To learn how to contribute to this project, see CONTRIBUTING_.
+To learn how to contribute to this project, see CONTRIBUTING.md_.
 
-.. _CONTRIBUTING: CONTRIBUTING.md
+.. _CONTRIBUTING.md: CONTRIBUTING.md

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = py3.{7,8,9,10,11},mypy
+envlist = py,flake8,isort,mypy
 
 [testenv]
 allowlist_externals = poetry


### PR DESCRIPTION
I didn't like how `CONTRIBUTING.md` wasn't referenced in the README or how [`tox` didn't run tests that our CI fails on](https://github.com/certbot/josepy/blob/3e936853a12123b2a9d5b16fa99874d872826a9d/.github/workflows/check.yaml#L39-L48).