### PR TITLE
Stop using pkg_resources

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1692,4 +1692,4 @@ docs = ["sphinx", "sphinx-rtd-theme"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "ae386819624c3f06520e38ae179c54fe1ac13bc8f61d4b6d5ed040afc583dc41"
+content-hash = "55dc61286dbb6b84f7773753a8bd95cf40fd0f016a44e29e6d9a9d09640cbbff"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1692,4 +1692,4 @@ docs = ["sphinx", "sphinx-rtd-theme"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "55dc61286dbb6b84f7773753a8bd95cf40fd0f016a44e29e6d9a9d09640cbbff"
+content-hash = "00a05617f792fdaf176f5e01777818e827187d733a781d210e11dbf25d1923c2"

--- a/poetry.lock
+++ b/poetry.lock
@@ -524,6 +524,25 @@ docs = ["jaraco.packaging (>=8.2)", "rst.linker (>=1.9)", "sphinx"]
 testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pep517", "pyfakefs", "pytest (>=4.6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy"]
 
 [[package]]
+name = "importlib-resources"
+version = "5.12.0"
+description = "Read resources from Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "importlib_resources-5.12.0-py3-none-any.whl", hash = "sha256:7b1deeebbf351c7578e09bf2f63fa2ce8b5ffec296e0d349139d43cca061a81a"},
+    {file = "importlib_resources-5.12.0.tar.gz", hash = "sha256:4be82589bf5c1d7999aedf2a45159d10cb3ca4f19b2271f8792bc8e6da7b22f6"},
+]
+
+[package.dependencies]
+zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+testing = ["flake8 (<5)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
+
+[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
@@ -1221,14 +1240,14 @@ jeepney = ">=0.6"
 
 [[package]]
 name = "setuptools"
-version = "67.4.0"
+version = "67.5.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "setuptools-67.4.0-py3-none-any.whl", hash = "sha256:f106dee1b506dee5102cc3f3e9e68137bbad6d47b616be7991714b0c62204251"},
-    {file = "setuptools-67.4.0.tar.gz", hash = "sha256:e5fd0a713141a4a105412233c63dc4e17ba0090c8e8334594ac790ec97792330"},
+    {file = "setuptools-67.5.1-py3-none-any.whl", hash = "sha256:1c39d42bda4cb89f7fdcad52b6762e3c309ec8f8715b27c684176b7d71283242"},
+    {file = "setuptools-67.5.1.tar.gz", hash = "sha256:15136a251127da2d2e77ac7a1bc231eb504654f7e3346d93613a13f2e2787535"},
 ]
 
 [package.extras]
@@ -1673,4 +1692,4 @@ docs = ["sphinx", "sphinx-rtd-theme"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "8a990fa52c9ff1e046b0716bfcc8ebb77a1f80cfcab540e63cfd01bd3ee90b71"
+content-hash = "ae386819624c3f06520e38ae179c54fe1ac13bc8f61d4b6d5ed040afc583dc41"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ coverage = {version = ">=4.0", extras = ["toml"]}
 # https://github.com/PyCQA/flake8/issues/1701.
 flake8 = ">=4.0"
 flake8-assertive = "*"
+importlib_resources = {version = "*", python = "<3.9"}
 isort = "*"
 mypy = "*"
 types-pyOpenSSL = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,10 @@ coverage = {version = ">=4.0", extras = ["toml"]}
 # https://github.com/PyCQA/flake8/issues/1701.
 flake8 = ">=4.0"
 flake8-assertive = "*"
-importlib_resources = {version = "*", python = "<3.9"}
+# importlib_resources 1.3 was the version included in Python 3.9 which
+# introduced the functionality we are using. See
+# https://github.com/python/importlib_resources/tree/7f4fbb5ee026d7610636d5ece18b09c64aa0c893#compatibility.
+importlib_resources = {version = ">=1.3", python = "<3.9"}
 isort = "*"
 mypy = "*"
 types-pyOpenSSL = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,9 +42,6 @@ python = "^3.7"
 cryptography = ">=1.5"
 # Connection.set_tlsext_host_name (>=0.13)
 pyopenssl = ">=0.13"
-# For pkg_resources. >=1.0 so pip resolves it to a version cryptography
-# will tolerate; see #2599:
-setuptools = ">=1.0"
 # >=4.3.0 is needed for Python 3.10 support
 sphinx = {version = ">=4.3.0", optional = true}
 sphinx-rtd-theme = {version = ">=1.0", optional = true}

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -25,6 +25,8 @@ TESTDATA = importlib_resources.files('testdata')
 
 def vector_path(*names: str) -> str:
     """Path to a test vector."""
+    # This code is based on the recommendation at
+    # https://web.archive.org/web/20230131043552/https://importlib-resources.readthedocs.io/en/latest/migration.html#pkg-resources-resource-filename.
     file_manager = contextlib.ExitStack()
     atexit.register(file_manager.close)
     ref = TESTDATA.joinpath(*names)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,6 +2,7 @@
 import atexit
 import contextlib
 import os
+import sys
 from typing import Any
 
 from cryptography.hazmat.backends import default_backend
@@ -12,10 +13,12 @@ import josepy.util
 from josepy import ComparableRSAKey, ComparableX509
 from josepy.util import ComparableECKey
 
-try:
-    import importlib_resources
-except ImportError:
+# This approach is based on the recommendation at
+# https://github.com/python/mypy/issues/1153#issuecomment-1207333806.
+if sys.version_info >= (3, 9):
     import importlib.resources as importlib_resources
+else:
+    import importlib_resources
 
 TESTDATA = importlib_resources.files('testdata')
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -28,6 +28,8 @@ def vector_path(*names: str) -> str:
     file_manager = contextlib.ExitStack()
     atexit.register(file_manager.close)
     ref = TESTDATA.joinpath(*names)
+    # We convert the value to str here because some of the calling code doesn't
+    # work with pathlib objects.
     return str(file_manager.enter_context(importlib_resources.as_file(ref)))
 
 


### PR DESCRIPTION
When working on #157, I got errors because [the new version of `setuptools` deprecates `pkg_resources`](https://setuptools.pypa.io/en/latest/history.html#v67-5-0). To fix that, I used the "Attention" message at the top of https://setuptools.pypa.io/en/latest/pkg_resources.html and https://importlib-resources.readthedocs.io/en/latest/index.html. Importing `testdata` as a package like this after adding `__init__.py` Just Works™ for the same reason `import test_util` works.