### PR TITLE
Is this the part where I say "paint it black"?

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Introduced the black code formatter
+48729269a5a790473cb760c03577faa1b2c3245b

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -35,17 +35,8 @@ jobs:
             ${{ runner.os }}-
       - name: Install Poetry & Tox
         run: pip install poetry>1.0.0 tox>3.3.0
-      # TEST
-      - name: Run pytest and coverage
-        run: tox -e py
-      # STATIC CHECK
-      - name: Run mypy
-        run: tox -e mypy
-      # LINTING
-      - name: Run flake8 and isort
-        run: |
-          tox -e flake8
-          tox -e isort
+      - name: Run tox
+        run: tox
   # This job runs our tests like external parties such as packagers.
   external:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,10 @@ files: |
       tests
     )/
 repos:
+  - repo: https://github.com/psf/black
+    rev: 23.1.0
+    hooks:
+      - id: black
   - repo: https://github.com/pycqa/flake8
     rev: 5.0.4
     hooks:

--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,9 @@ JOSE protocol implementation in Python using cryptography
 .. image:: https://readthedocs.org/projects/josepy/badge/?version=latest
   :target: http://josepy.readthedocs.io/en/latest/?badge=latest
 
+.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
+  :target: https://github.com/psf/black
+
 Originally developed as part of the ACME_ protocol implementation.
 
 .. _ACME: https://pypi.python.org/pypi/acme

--- a/poetry.lock
+++ b/poetry.lock
@@ -47,6 +47,57 @@ files = [
 pytz = {version = ">=2015.7", markers = "python_version < \"3.9\""}
 
 [[package]]
+name = "black"
+version = "23.1.0"
+description = "The uncompromising code formatter."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "black-23.1.0-cp310-cp310-macosx_10_16_arm64.whl", hash = "sha256:b6a92a41ee34b883b359998f0c8e6eb8e99803aa8bf3123bf2b2e6fec505a221"},
+    {file = "black-23.1.0-cp310-cp310-macosx_10_16_universal2.whl", hash = "sha256:57c18c5165c1dbe291d5306e53fb3988122890e57bd9b3dcb75f967f13411a26"},
+    {file = "black-23.1.0-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:9880d7d419bb7e709b37e28deb5e68a49227713b623c72b2b931028ea65f619b"},
+    {file = "black-23.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e6663f91b6feca5d06f2ccd49a10f254f9298cc1f7f49c46e498a0771b507104"},
+    {file = "black-23.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:9afd3f493666a0cd8f8df9a0200c6359ac53940cbde049dcb1a7eb6ee2dd7074"},
+    {file = "black-23.1.0-cp311-cp311-macosx_10_16_arm64.whl", hash = "sha256:bfffba28dc52a58f04492181392ee380e95262af14ee01d4bc7bb1b1c6ca8d27"},
+    {file = "black-23.1.0-cp311-cp311-macosx_10_16_universal2.whl", hash = "sha256:c1c476bc7b7d021321e7d93dc2cbd78ce103b84d5a4cf97ed535fbc0d6660648"},
+    {file = "black-23.1.0-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:382998821f58e5c8238d3166c492139573325287820963d2f7de4d518bd76958"},
+    {file = "black-23.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bf649fda611c8550ca9d7592b69f0637218c2369b7744694c5e4902873b2f3a"},
+    {file = "black-23.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:121ca7f10b4a01fd99951234abdbd97728e1240be89fde18480ffac16503d481"},
+    {file = "black-23.1.0-cp37-cp37m-macosx_10_16_x86_64.whl", hash = "sha256:a8471939da5e824b891b25751955be52ee7f8a30a916d570a5ba8e0f2eb2ecad"},
+    {file = "black-23.1.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8178318cb74f98bc571eef19068f6ab5613b3e59d4f47771582f04e175570ed8"},
+    {file = "black-23.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:a436e7881d33acaf2536c46a454bb964a50eff59b21b51c6ccf5a40601fbef24"},
+    {file = "black-23.1.0-cp38-cp38-macosx_10_16_arm64.whl", hash = "sha256:a59db0a2094d2259c554676403fa2fac3473ccf1354c1c63eccf7ae65aac8ab6"},
+    {file = "black-23.1.0-cp38-cp38-macosx_10_16_universal2.whl", hash = "sha256:0052dba51dec07ed029ed61b18183942043e00008ec65d5028814afaab9a22fd"},
+    {file = "black-23.1.0-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:49f7b39e30f326a34b5c9a4213213a6b221d7ae9d58ec70df1c4a307cf2a1580"},
+    {file = "black-23.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:162e37d49e93bd6eb6f1afc3e17a3d23a823042530c37c3c42eeeaf026f38468"},
+    {file = "black-23.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:8b70eb40a78dfac24842458476135f9b99ab952dd3f2dab738c1881a9b38b753"},
+    {file = "black-23.1.0-cp39-cp39-macosx_10_16_arm64.whl", hash = "sha256:a29650759a6a0944e7cca036674655c2f0f63806ddecc45ed40b7b8aa314b651"},
+    {file = "black-23.1.0-cp39-cp39-macosx_10_16_universal2.whl", hash = "sha256:bb460c8561c8c1bec7824ecbc3ce085eb50005883a6203dcfb0122e95797ee06"},
+    {file = "black-23.1.0-cp39-cp39-macosx_10_16_x86_64.whl", hash = "sha256:c91dfc2c2a4e50df0026f88d2215e166616e0c80e86004d0003ece0488db2739"},
+    {file = "black-23.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2a951cc83ab535d248c89f300eccbd625e80ab880fbcfb5ac8afb5f01a258ac9"},
+    {file = "black-23.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:0680d4380db3719ebcfb2613f34e86c8e6d15ffeabcf8ec59355c5e7b85bb555"},
+    {file = "black-23.1.0-py3-none-any.whl", hash = "sha256:7a0f701d314cfa0896b9001df70a530eb2472babb76086344e688829efd97d32"},
+    {file = "black-23.1.0.tar.gz", hash = "sha256:b0bd97bea8903f5a2ba7219257a44e3f1f9d00073d6cc1add68f0beec69692ac"},
+]
+
+[package.dependencies]
+click = ">=8.0.0"
+mypy-extensions = ">=0.4.3"
+packaging = ">=22.0"
+pathspec = ">=0.9.0"
+platformdirs = ">=2"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\" and implementation_name == \"cpython\""}
+typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
+
+[package.extras]
+colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.7.4)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
 name = "bleach"
 version = "6.0.0"
 description = "An easy safelist-based HTML-sanitizing tool."
@@ -250,6 +301,22 @@ files = [
     {file = "charset_normalizer-3.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:830d2948a5ec37c386d3170c483063798d7879037492540f10a475e3fd6f244b"},
     {file = "charset_normalizer-3.1.0-py3-none-any.whl", hash = "sha256:3d9098b479e78c85080c98e1e35ff40b4a31d8953102bb0fd7d1b6f8a2111a3d"},
 ]
+
+[[package]]
+name = "click"
+version = "8.1.3"
+description = "Composable command line interface toolkit"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
+    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "colorama"
@@ -855,6 +922,18 @@ python-versions = ">=3.7"
 files = [
     {file = "packaging-23.0-py3-none-any.whl", hash = "sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2"},
     {file = "packaging-23.0.tar.gz", hash = "sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97"},
+]
+
+[[package]]
+name = "pathspec"
+version = "0.11.0"
+description = "Utility library for gitignore style pattern matching of file paths."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pathspec-0.11.0-py3-none-any.whl", hash = "sha256:3a66eb970cbac598f9e5ccb5b2cf58930cd8e3ed86d393d541eaf2d8b1705229"},
+    {file = "pathspec-0.11.0.tar.gz", hash = "sha256:64d338d4e0914e91c1792321e6907b5a593f1ab1851de7fc269557a21b30ebbc"},
 ]
 
 [[package]]
@@ -1692,4 +1771,4 @@ docs = ["sphinx", "sphinx-rtd-theme"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "00a05617f792fdaf176f5e01777818e827187d733a781d210e11dbf25d1923c2"
+content-hash = "2ba9212ec21b305a1b79bed6e3462cfd6f792776333c6cea3d4bc923ebecca49"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,8 @@ include = [
 ]
 
 [tool.poetry.dependencies]
+# This should be kept in sync with the value of target-version in our
+# configuration for black below.
 python = "^3.7"
 # load_pem_private/public_key (>=0.6)
 # rsa_recover_prime_factors (>=0.8)
@@ -47,6 +49,7 @@ sphinx = {version = ">=4.3.0", optional = true}
 sphinx-rtd-theme = {version = ">=1.0", optional = true}
 
 [tool.poetry.dev-dependencies]
+black = "*"
 # coverage[toml] extra is required to read the coverage config from pyproject.toml
 coverage = {version = ">=4.0", extras = ["toml"]}
 # flake8 3.x doesn't work on Python 3.7. See
@@ -79,6 +82,13 @@ docs = [
 [tool.poetry.scripts]
 jws = "josepy.jws:CLI.run"
 
+# Black tooling configuration
+[tool.black]
+line-length = 100
+# This should be kept in sync with the version of Python specified in poetry's
+# dependencies above.
+target-version = ['py37', 'py38', 'py39', 'py310', 'py311']
+
 # Mypy tooling configuration
 
 [tool.mypy]
@@ -98,10 +108,9 @@ norecursedirs = "*.egg .eggs dist build docs .tox"
 [tool.isort]
 combine_as_imports = false
 default_section = "THIRDPARTY"
-include_trailing_comma = true
 known_first_party = "josepy"
 line_length = 79
-multi_line_output = 3
+profile = "black"
 
 # Coverage tooling configuration
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,5 @@
 [flake8]
 exclude = .git,.tox
-ignore = W504
+# E203 and W503 are ignored here for compatibility with black
+ignore = E203,W503,W504
 max-line-length = 100

--- a/src/josepy/b64.py
+++ b/src/josepy/b64.py
@@ -27,8 +27,8 @@ def b64encode(data: bytes) -> bytes:
 
     """
     if not isinstance(data, bytes):
-        raise TypeError('argument should be bytes')
-    return base64.urlsafe_b64encode(data).rstrip(b'=')
+        raise TypeError("argument should be bytes")
+    return base64.urlsafe_b64encode(data).rstrip(b"=")
 
 
 def b64decode(data: Union[bytes, str]) -> bytes:
@@ -47,11 +47,10 @@ def b64decode(data: Union[bytes, str]) -> bytes:
     """
     if isinstance(data, str):
         try:
-            data = data.encode('ascii')
+            data = data.encode("ascii")
         except UnicodeEncodeError:
-            raise ValueError(
-                'unicode argument should contain only ASCII characters')
+            raise ValueError("unicode argument should contain only ASCII characters")
     elif not isinstance(data, bytes):
-        raise TypeError('argument should be a str or unicode')
+        raise TypeError("argument should be a str or unicode")
 
-    return base64.urlsafe_b64decode(data + b'=' * (4 - (len(data) % 4)))
+    return base64.urlsafe_b64decode(data + b"=" * (4 - (len(data) % 4)))

--- a/src/josepy/errors.py
+++ b/src/josepy/errors.py
@@ -10,8 +10,7 @@ class DeserializationError(Error):
     """JSON deserialization error."""
 
     def __str__(self) -> str:
-        return "Deserialization error: {0}".format(
-            super().__str__())
+        return "Deserialization error: {0}".format(super().__str__())
 
 
 class SerializationError(Error):
@@ -32,5 +31,4 @@ class UnrecognizedTypeError(DeserializationError):
         super().__init__(str(self))
 
     def __str__(self) -> str:
-        return '{0} was not recognized, full message: {1}'.format(
-            self.typ, self.jobj)
+        return "{0} was not recognized, full message: {1}".format(self.typ, self.jobj)

--- a/src/josepy/interfaces.py
+++ b/src/josepy/interfaces.py
@@ -128,6 +128,7 @@ class JSONDeSerializable(metaclass=abc.ABCMeta):
         :returns: Fully serialized object.
 
         """
+
         def _serialize(obj: Any) -> Any:
             if isinstance(obj, JSONDeSerializable):
                 return _serialize(obj.to_partial_json())
@@ -140,8 +141,7 @@ class JSONDeSerializable(metaclass=abc.ABCMeta):
                 # unhashable list
                 return tuple(_serialize(subobj) for subobj in obj)
             elif isinstance(obj, Mapping):
-                return {_serialize(key): _serialize(value)
-                        for key, value in obj.items()}
+                return {_serialize(key): _serialize(value) for key, value in obj.items()}
             else:
                 return obj
 
@@ -167,8 +167,9 @@ class JSONDeSerializable(metaclass=abc.ABCMeta):
         return cls()
 
     @classmethod
-    def json_loads(cls: Type[GenericJSONDeSerializable],
-                   json_string: Union[str, bytes]) -> GenericJSONDeSerializable:
+    def json_loads(
+        cls: Type[GenericJSONDeSerializable], json_string: Union[str, bytes]
+    ) -> GenericJSONDeSerializable:
         """Deserialize from JSON document string."""
         try:
             loads = json.loads(json_string)
@@ -191,10 +192,10 @@ class JSONDeSerializable(metaclass=abc.ABCMeta):
         :rtype: str
 
         """
-        return self.json_dumps(sort_keys=True, indent=4, separators=(',', ': '))
+        return self.json_dumps(sort_keys=True, indent=4, separators=(",", ": "))
 
     @classmethod
-    def json_dump_default(cls, python_object: 'JSONDeSerializable') -> Any:
+    def json_dump_default(cls, python_object: "JSONDeSerializable") -> Any:
         """Serialize Python object.
 
         This function is meant to be passed as ``default`` to
@@ -210,4 +211,4 @@ class JSONDeSerializable(metaclass=abc.ABCMeta):
         if isinstance(python_object, JSONDeSerializable):
             return python_object.to_partial_json()
         else:  # this branch is necessary, cannot just "return"
-            raise TypeError(repr(python_object) + ' is not JSON serializable')
+            raise TypeError(repr(python_object) + " is not JSON serializable")

--- a/src/josepy/json_util.py
+++ b/src/josepy/json_util.py
@@ -28,9 +28,13 @@ from josepy import b64, errors, interfaces, util
 logger = logging.getLogger(__name__)
 
 
-def field(json_name: str, default: Any = None, omitempty: bool = False,
-          decoder: Optional[Callable[[Any], Any]] = None,
-          encoder: Optional[Callable[[Any], Any]] = None) -> Any:
+def field(
+    json_name: str,
+    default: Any = None,
+    omitempty: bool = False,
+    decoder: Optional[Callable[[Any], Any]] = None,
+    encoder: Optional[Callable[[Any], Any]] = None,
+) -> Any:
     """Convenient function to declare a :class:`Field` with proper type annotations.
 
     This function allows to write the following code:
@@ -43,8 +47,9 @@ def field(json_name: str, default: Any = None, omitempty: bool = False,
             return self.typ
 
     """
-    return _TypedField(json_name=json_name, default=default, omitempty=omitempty,
-                       decoder=decoder, encoder=encoder)
+    return _TypedField(
+        json_name=json_name, default=default, omitempty=omitempty, decoder=decoder, encoder=encoder
+    )
 
 
 class Field:
@@ -71,11 +76,17 @@ class Field:
         deserializing.
 
     """
-    __slots__ = ('json_name', 'default', 'omitempty', 'fdec', 'fenc')
 
-    def __init__(self, json_name: str, default: Any = None, omitempty: bool = False,
-                 decoder: Optional[Callable[[Any], Any]] = None,
-                 encoder: Optional[Callable[[Any], Any]] = None) -> None:
+    __slots__ = ("json_name", "default", "omitempty", "fdec", "fenc")
+
+    def __init__(
+        self,
+        json_name: str,
+        default: Any = None,
+        omitempty: bool = False,
+        decoder: Optional[Callable[[Any], Any]] = None,
+        encoder: Optional[Callable[[Any], Any]] = None,
+    ) -> None:
         self.json_name = json_name
         self.default = default
         self.omitempty = omitempty
@@ -97,7 +108,7 @@ class Field:
         """Omit the value in output?"""
         return self._empty(value) and self.omitempty
 
-    def _update_params(self, **kwargs: Any) -> 'Field':
+    def _update_params(self, **kwargs: Any) -> "Field":
         current = {
             "json_name": self.json_name,
             "default": self.default,
@@ -108,11 +119,11 @@ class Field:
         }
         return type(self)(**current)
 
-    def decoder(self, fdec: Callable[[Any], Any]) -> 'Field':
+    def decoder(self, fdec: Callable[[Any], Any]) -> "Field":
         """Descriptor to change the decoder on JSON object field."""
         return self._update_params(decoder=fdec)
 
-    def encoder(self, fenc: Callable[[Any], Any]) -> 'Field':
+    def encoder(self, fenc: Callable[[Any], Any]) -> "Field":
         """Descriptor to change the encoder on JSON object field."""
         return self._update_params(encoder=fenc)
 
@@ -138,8 +149,11 @@ class Field:
             return tuple(cls.default_decoder(subvalue) for subvalue in value)
         elif isinstance(value, dict):
             return util.frozendict(
-                {cls.default_decoder(key): cls.default_decoder(value)
-                 for key, value in value.items()})
+                {
+                    cls.default_decoder(key): cls.default_decoder(value)
+                    for key, value in value.items()
+                }
+            )
         else:  # integer or string
             return value
 
@@ -203,12 +217,13 @@ class JSONObjectWithFieldsMeta(abc.ABCMeta):
     _fields: Dict[str, Field] = {}
     _orig_slots: Iterable[str]
 
-    def __new__(mcs, name: str, bases: List[str],
-                namespace: Dict[str, Any]) -> 'JSONObjectWithFieldsMeta':
+    def __new__(
+        mcs, name: str, bases: List[str], namespace: Dict[str, Any]
+    ) -> "JSONObjectWithFieldsMeta":
         fields: Dict[str, Field] = {}
 
         for base in bases:
-            fields.update(getattr(base, '_fields', {}))
+            fields.update(getattr(base, "_fields", {}))
         # Do not reorder, this class might override fields from base classes!
         # We use a copy of namespace in the loop because the loop modifies it.
         for key, value in namespace.copy().items():
@@ -216,25 +231,25 @@ class JSONObjectWithFieldsMeta(abc.ABCMeta):
                 if isinstance(value, _TypedField):
                     # Ensure the type annotation has been set for the field.
                     # Error out if it is not the case.
-                    if key not in namespace.get('__annotations__', {}):
+                    if key not in namespace.get("__annotations__", {}):
                         raise ValueError(
-                            f'Field `{key}` in JSONObject `{name}` has no type annotation.')
+                            f"Field `{key}` in JSONObject `{name}` has no type annotation."
+                        )
                 fields[key] = namespace.pop(key)
 
-        namespace['_orig_slots'] = namespace.get('__slots__', ())
-        namespace['__slots__'] = tuple(
-            list(namespace['_orig_slots']) + list(fields.keys()))
-        namespace['_fields'] = fields
+        namespace["_orig_slots"] = namespace.get("__slots__", ())
+        namespace["__slots__"] = tuple(list(namespace["_orig_slots"]) + list(fields.keys()))
+        namespace["_fields"] = fields
 
         return abc.ABCMeta.__new__(mcs, name, bases, namespace)  # type: ignore[arg-type]
 
 
-GenericJSONObjectWithFields = TypeVar('GenericJSONObjectWithFields', bound='JSONObjectWithFields')
+GenericJSONObjectWithFields = TypeVar("GenericJSONObjectWithFields", bound="JSONObjectWithFields")
 
 
-class JSONObjectWithFields(util.ImmutableMap,
-                           interfaces.JSONDeSerializable,
-                           metaclass=JSONObjectWithFieldsMeta):
+class JSONObjectWithFields(
+    util.ImmutableMap, interfaces.JSONDeSerializable, metaclass=JSONObjectWithFieldsMeta
+):
     """JSON object with fields.
 
     Example::
@@ -260,12 +275,11 @@ class JSONObjectWithFields(util.ImmutableMap,
       assert Foo(bar='baz').bar == 'baz'
 
     """
+
     @classmethod
     def _defaults(cls) -> Dict[str, Any]:
         """Get default fields values."""
-        return {
-            slot: field.default for slot, field in cls._fields.items()
-        }
+        return {slot: field.default for slot, field in cls._fields.items()}
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**{**self._defaults(), **kwargs})
@@ -300,8 +314,8 @@ class JSONObjectWithFields(util.ImmutableMap,
                     jobj[field.json_name] = field.encode(value)
                 except errors.SerializationError as error:
                     raise errors.SerializationError(
-                        'Could not encode {0} ({1}): {2}'.format(
-                            slot, value, error))
+                        "Could not encode {0} ({1}): {2}".format(slot, value, error)
+                    )
         return jobj
 
     def to_partial_json(self) -> Dict[str, Any]:
@@ -316,8 +330,8 @@ class JSONObjectWithFields(util.ImmutableMap,
 
         if missing:
             raise errors.DeserializationError(
-                'The following fields are required: {0}'.format(
-                    ','.join(missing)))
+                "The following fields are required: {0}".format(",".join(missing))
+            )
 
     @classmethod
     def fields_from_json(cls, jobj: Mapping[str, Any]) -> Any:
@@ -332,8 +346,9 @@ class JSONObjectWithFields(util.ImmutableMap,
                 try:
                     fields[slot] = field.decode(value)
                 except errors.DeserializationError as error:
-                    raise errors.DeserializationError('Could not decode {0!r} ({1!r}): {2}'.format(
-                        slot, value, error))
+                    raise errors.DeserializationError(
+                        "Could not decode {0!r} ({1!r}): {2}".format(slot, value, error)
+                    )
         return fields
 
     @classmethod
@@ -351,7 +366,7 @@ def encode_b64jose(data: bytes) -> str:
 
     """
     # b64encode produces ASCII characters only
-    return b64.b64encode(data).decode('ascii')
+    return b64.b64encode(data).decode("ascii")
 
 
 def decode_b64jose(data: str, size: Optional[int] = None, minimum: bool = False) -> bytes:
@@ -370,10 +385,10 @@ def decode_b64jose(data: str, size: Optional[int] = None, minimum: bool = False)
     except binascii.Error as error:
         raise errors.DeserializationError(error)
 
-    if size is not None and ((not minimum and len(decoded) != size) or
-                             (minimum and len(decoded) < size)):
-        raise errors.DeserializationError(
-            "Expected at least or exactly {0} bytes".format(size))
+    if size is not None and (
+        (not minimum and len(decoded) != size) or (minimum and len(decoded) < size)
+    ):
+        raise errors.DeserializationError("Expected at least or exactly {0} bytes".format(size))
 
     return decoded
 
@@ -400,8 +415,9 @@ def decode_hex16(value: str, size: Optional[int] = None, minimum: bool = False) 
 
     """
     value_b = value.encode()
-    if size is not None and ((not minimum and len(value_b) != size * 2) or
-                             (minimum and len(value_b) < size * 2)):
+    if size is not None and (
+        (not minimum and len(value_b) != size * 2) or (minimum and len(value_b) < size * 2)
+    ):
         raise errors.DeserializationError()
     try:
         return binascii.unhexlify(value_b)
@@ -419,8 +435,7 @@ def encode_cert(cert: util.ComparableX509) -> str:
     if isinstance(cert.wrapped, crypto.X509Req):
         raise ValueError("Error input is actually a certificate request.")
 
-    return encode_b64jose(crypto.dump_certificate(
-        crypto.FILETYPE_ASN1, cert.wrapped))
+    return encode_b64jose(crypto.dump_certificate(crypto.FILETYPE_ASN1, cert.wrapped))
 
 
 def decode_cert(b64der: str) -> util.ComparableX509:
@@ -431,8 +446,9 @@ def decode_cert(b64der: str) -> util.ComparableX509:
 
     """
     try:
-        return util.ComparableX509(crypto.load_certificate(
-            crypto.FILETYPE_ASN1, decode_b64jose(b64der)))
+        return util.ComparableX509(
+            crypto.load_certificate(crypto.FILETYPE_ASN1, decode_b64jose(b64der))
+        )
     except crypto.Error as error:
         raise errors.DeserializationError(error)
 
@@ -447,8 +463,7 @@ def encode_csr(csr: util.ComparableX509) -> str:
     if isinstance(csr.wrapped, crypto.X509):
         raise ValueError("Error input is actually a certificate.")
 
-    return encode_b64jose(crypto.dump_certificate_request(
-        crypto.FILETYPE_ASN1, csr.wrapped))
+    return encode_b64jose(crypto.dump_certificate_request(crypto.FILETYPE_ASN1, csr.wrapped))
 
 
 def decode_csr(b64der: str) -> util.ComparableX509:
@@ -459,14 +474,16 @@ def decode_csr(b64der: str) -> util.ComparableX509:
 
     """
     try:
-        return util.ComparableX509(crypto.load_certificate_request(
-            crypto.FILETYPE_ASN1, decode_b64jose(b64der)))
+        return util.ComparableX509(
+            crypto.load_certificate_request(crypto.FILETYPE_ASN1, decode_b64jose(b64der))
+        )
     except crypto.Error as error:
         raise errors.DeserializationError(error)
 
 
 GenericTypedJSONObjectWithFields = TypeVar(
-    'GenericTypedJSONObjectWithFields', bound='TypedJSONObjectWithFields')
+    "GenericTypedJSONObjectWithFields", bound="TypedJSONObjectWithFields"
+)
 
 
 class TypedJSONObjectWithFields(JSONObjectWithFields):
@@ -486,8 +503,9 @@ class TypedJSONObjectWithFields(JSONObjectWithFields):
     """Types registered for JSON deserialization"""
 
     @classmethod
-    def register(cls, type_cls: Type[GenericTypedJSONObjectWithFields],
-                 typ: Optional[str] = None) -> Type[GenericTypedJSONObjectWithFields]:
+    def register(
+        cls, type_cls: Type[GenericTypedJSONObjectWithFields], typ: Optional[str] = None
+    ) -> Type[GenericTypedJSONObjectWithFields]:
         """Register class for JSON deserialization."""
         typ = type_cls.typ if typ is None else typ
         cls.TYPES[typ] = type_cls
@@ -499,15 +517,15 @@ class TypedJSONObjectWithFields(JSONObjectWithFields):
         if cls in cls.TYPES.values():
             if cls.type_field_name not in jobj:
                 raise errors.DeserializationError(
-                    "Missing type field ({0})".format(cls.type_field_name))
+                    "Missing type field ({0})".format(cls.type_field_name)
+                )
             # cls is already registered type_cls, force to use it
             # so that, e.g Revocation.from_json(jobj) fails if
             # jobj["type"] != "revocation".
             return cls
 
         if not isinstance(jobj, dict):
-            raise errors.DeserializationError(
-                "{0} is not a dictionary object".format(jobj))
+            raise errors.DeserializationError("{0} is not a dictionary object".format(jobj))
         try:
             typ = jobj[cls.type_field_name]
         except KeyError:

--- a/src/josepy/jwk.py
+++ b/src/josepy/jwk.py
@@ -28,8 +28,9 @@ logger = logging.getLogger(__name__)
 
 class JWK(json_util.TypedJSONObjectWithFields, metaclass=abc.ABCMeta):
     """JSON Web Key."""
-    type_field_name = 'kty'
-    TYPES: Dict[str, Type['JWK']] = {}
+
+    type_field_name = "kty"
+    TYPES: Dict[str, Type["JWK"]] = {}
     cryptography_key_types: Tuple[Type[Any], ...] = ()
     """Subclasses should override."""
 
@@ -39,16 +40,17 @@ class JWK(json_util.TypedJSONObjectWithFields, metaclass=abc.ABCMeta):
     _thumbprint_json_dumps_params: Dict[str, Union[Optional[int], Sequence[str], bool]] = {
         # "no whitespace or line breaks before or after any syntactic
         # elements"
-        'indent': None,
-        'separators': (',', ':'),
+        "indent": None,
+        "separators": (",", ":"),
         # "members ordered lexicographically by the Unicode [UNICODE]
         # code points of the member names"
-        'sort_keys': True,
+        "sort_keys": True,
     }
     key: Any
 
-    def thumbprint(self,
-                   hash_function: Callable[[], hashes.HashAlgorithm] = hashes.SHA256) -> bytes:
+    def thumbprint(
+        self, hash_function: Callable[[], hashes.HashAlgorithm] = hashes.SHA256
+    ) -> bytes:
         """Compute JWK Thumbprint.
 
         https://tools.ietf.org/html/rfc7638
@@ -57,14 +59,16 @@ class JWK(json_util.TypedJSONObjectWithFields, metaclass=abc.ABCMeta):
 
         """
         digest = hashes.Hash(hash_function(), backend=default_backend())
-        digest.update(json.dumps(
-            {k: v for k, v in self.to_json().items()
-                if k in self.required},
-            **self._thumbprint_json_dumps_params).encode())  # type: ignore[arg-type]
+        digest.update(
+            json.dumps(
+                {k: v for k, v in self.to_json().items() if k in self.required},
+                **self._thumbprint_json_dumps_params,
+            ).encode()
+        )  # type: ignore[arg-type]
         return digest.finalize()
 
     @abc.abstractmethod
-    def public_key(self) -> 'JWK':  # pragma: no cover
+    def public_key(self) -> "JWK":  # pragma: no cover
         """Generate JWK with public key.
 
         For symmetric cryptosystems, this would return ``self``.
@@ -73,37 +77,38 @@ class JWK(json_util.TypedJSONObjectWithFields, metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
     @classmethod
-    def _load_cryptography_key(cls, data: bytes, password: Optional[bytes] = None,
-                               backend: Optional[Any] = None) -> Any:
+    def _load_cryptography_key(
+        cls, data: bytes, password: Optional[bytes] = None, backend: Optional[Any] = None
+    ) -> Any:
         backend = default_backend() if backend is None else backend
         exceptions = {}
 
         # private key?
         loader_private: Any
-        for loader_private in (serialization.load_pem_private_key,
-                               serialization.load_der_private_key):
+        for loader_private in (
+            serialization.load_pem_private_key,
+            serialization.load_der_private_key,
+        ):
             try:
                 return loader_private(data, password, backend)
-            except (ValueError, TypeError,
-                    cryptography.exceptions.UnsupportedAlgorithm) as error:
+            except (ValueError, TypeError, cryptography.exceptions.UnsupportedAlgorithm) as error:
                 exceptions[str(loader_private)] = error
 
         # public key?
         loader_public: Any
-        for loader_public in (serialization.load_pem_public_key,
-                              serialization.load_der_public_key):
+        for loader_public in (serialization.load_pem_public_key, serialization.load_der_public_key):
             try:
                 return loader_public(data, backend)
-            except (ValueError,
-                    cryptography.exceptions.UnsupportedAlgorithm) as error:
+            except (ValueError, cryptography.exceptions.UnsupportedAlgorithm) as error:
                 exceptions[str(loader_public)] = error
 
         # no luck
-        raise errors.Error('Unable to deserialize key: {0}'.format(exceptions))
+        raise errors.Error("Unable to deserialize key: {0}".format(exceptions))
 
     @classmethod
-    def load(cls, data: bytes, password: Optional[bytes] = None,
-             backend: Optional[Any] = None) -> 'JWK':
+    def load(
+        cls, data: bytes, password: Optional[bytes] = None, backend: Optional[Any] = None
+    ) -> "JWK":
         """Load serialized key as JWK.
 
         :param str data: Public or private key serialized as PEM or DER.
@@ -121,24 +126,26 @@ class JWK(json_util.TypedJSONObjectWithFields, metaclass=abc.ABCMeta):
         try:
             key = cls._load_cryptography_key(data, password, backend)
         except errors.Error as error:
-            logger.debug('Loading symmetric key, asymmetric failed: %s', error)
+            logger.debug("Loading symmetric key, asymmetric failed: %s", error)
             return JWKOct(key=data)
 
         if cls.typ is not NotImplemented and not isinstance(key, cls.cryptography_key_types):
-            raise errors.Error('Unable to deserialize {0} into {1}'.format(
-                key.__class__, cls.__class__))
+            raise errors.Error(
+                "Unable to deserialize {0} into {1}".format(key.__class__, cls.__class__)
+            )
         for jwk_cls in cls.TYPES.values():
             if isinstance(key, jwk_cls.cryptography_key_types):
                 return jwk_cls(key=key)
-        raise errors.Error('Unsupported algorithm: {0}'.format(key.__class__))
+        raise errors.Error("Unsupported algorithm: {0}".format(key.__class__))
 
 
 @JWK.register
 class JWKOct(JWK):
     """Symmetric JWK."""
-    typ = 'oct'
-    __slots__ = ('key',)
-    required = ('k', JWK.type_field_name)
+
+    typ = "oct"
+    __slots__ = ("key",)
+    required = ("k", JWK.type_field_name)
     key: bytes
 
     def fields_to_partial_json(self) -> Dict[str, str]:
@@ -146,13 +153,13 @@ class JWKOct(JWK):
         # algorithm intended to be used with the key, unless the
         # application uses another means or convention to determine
         # the algorithm used.
-        return {'k': json_util.encode_b64jose(self.key)}
+        return {"k": json_util.encode_b64jose(self.key)}
 
     @classmethod
-    def fields_from_json(cls, jobj: Mapping[str, Any]) -> 'JWKOct':
-        return cls(key=json_util.decode_b64jose(jobj['k']))
+    def fields_from_json(cls, jobj: Mapping[str, Any]) -> "JWKOct":
+        return cls(key=json_util.decode_b64jose(jobj["k"]))
 
-    def public_key(self) -> 'JWKOct':
+    def public_key(self) -> "JWKOct":
         return self
 
 
@@ -165,16 +172,16 @@ class JWKRSA(JWK):
         in :class:`~josepy.util.ComparableRSAKey`
 
     """
-    typ = 'RSA'
+
+    typ = "RSA"
     cryptography_key_types = (rsa.RSAPublicKey, rsa.RSAPrivateKey)
-    __slots__ = ('key',)
-    required = ('e', JWK.type_field_name, 'n')
+    __slots__ = ("key",)
+    required = ("e", JWK.type_field_name, "n")
     key: josepy.util.ComparableRSAKey
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        if 'key' in kwargs and not isinstance(
-                kwargs['key'], util.ComparableRSAKey):
-            kwargs['key'] = util.ComparableRSAKey(kwargs['key'])
+        if "key" in kwargs and not isinstance(kwargs["key"], util.ComparableRSAKey):
+            kwargs["key"] = util.ComparableRSAKey(kwargs["key"])
         super().__init__(*args, **kwargs)
 
     @classmethod
@@ -198,35 +205,43 @@ class JWKRSA(JWK):
         except ValueError:  # invalid literal for long() with base 16
             raise errors.DeserializationError()
 
-    def public_key(self) -> 'JWKRSA':
+    def public_key(self) -> "JWKRSA":
         return type(self)(key=self.key.public_key())
 
     @classmethod
-    def fields_from_json(cls, jobj: Mapping[str, Any]) -> 'JWKRSA':
-        n, e = (cls._decode_param(jobj[x]) for x in ('n', 'e'))
+    def fields_from_json(cls, jobj: Mapping[str, Any]) -> "JWKRSA":
+        n, e = (cls._decode_param(jobj[x]) for x in ("n", "e"))
         public_numbers = rsa.RSAPublicNumbers(e=e, n=n)
 
         # public key
-        if 'd' not in jobj:
+        if "d" not in jobj:
             return cls(key=public_numbers.public_key(default_backend()))
 
         # private key
-        d = cls._decode_param(jobj['d'])
-        if ('p' in jobj or 'q' in jobj or 'dp' in jobj or
-                'dq' in jobj or 'qi' in jobj or 'oth' in jobj):
+        d = cls._decode_param(jobj["d"])
+        if (
+            "p" in jobj
+            or "q" in jobj
+            or "dp" in jobj
+            or "dq" in jobj
+            or "qi" in jobj
+            or "oth" in jobj
+        ):
             # "If the producer includes any of the other private
             # key parameters, then all of the others MUST be
             # present, with the exception of "oth", which MUST
             # only be present when more than two prime factors
             # were used."
-            p, q, dp, dq, qi, = all_params = tuple(
-                jobj.get(x) for x in ('p', 'q', 'dp', 'dq', 'qi'))
+            (
+                p,
+                q,
+                dp,
+                dq,
+                qi,
+            ) = all_params = tuple(jobj.get(x) for x in ("p", "q", "dp", "dq", "qi"))
             if tuple(param for param in all_params if param is None):
-                raise errors.Error(
-                    'Some private parameters are missing: {0}'.format(
-                        all_params))
-            p, q, dp, dq, qi = tuple(
-                cls._decode_param(str(x)) for x in all_params)
+                raise errors.Error("Some private parameters are missing: {0}".format(all_params))
+            p, q, dp, dq, qi = tuple(cls._decode_param(str(x)) for x in all_params)
 
             # TODO: check for oth
         else:
@@ -236,9 +251,9 @@ class JWKRSA(JWK):
             dq = rsa.rsa_crt_dmq1(d, q)
             qi = rsa.rsa_crt_iqmp(p, q)
 
-        key = rsa.RSAPrivateNumbers(
-            p, q, d, dp, dq, qi, public_numbers).private_key(
-                default_backend())
+        key = rsa.RSAPrivateNumbers(p, q, d, dp, dq, qi, public_numbers).private_key(
+            default_backend()
+        )
 
         return cls(key=key)
 
@@ -246,24 +261,23 @@ class JWKRSA(JWK):
         if isinstance(self.key._wrapped, rsa.RSAPublicKey):
             numbers = self.key.public_numbers()
             params = {
-                'n': numbers.n,
-                'e': numbers.e,
+                "n": numbers.n,
+                "e": numbers.e,
             }
         else:  # rsa.RSAPrivateKey
             private = self.key.private_numbers()
             public = self.key.public_key().public_numbers()
             params = {
-                'n': public.n,
-                'e': public.e,
-                'd': private.d,
-                'p': private.p,
-                'q': private.q,
-                'dp': private.dmp1,
-                'dq': private.dmq1,
-                'qi': private.iqmp,
+                "n": public.n,
+                "e": public.e,
+                "d": private.d,
+                "p": private.p,
+                "q": private.q,
+                "dp": private.dmp1,
+                "dq": private.dmq1,
+                "qi": private.iqmp,
             }
-        return {key: self._encode_param(value)
-                for key, value in params.items()}
+        return {key: self._encode_param(value) for key, value in params.items()}
 
 
 @JWK.register
@@ -275,17 +289,16 @@ class JWKEC(JWK):
         in :class:`~josepy.util.ComparableECKey`
 
     """
-    typ = 'EC'
-    __slots__ = ('key',)
-    cryptography_key_types = (
-        ec.EllipticCurvePublicKey, ec.EllipticCurvePrivateKey)
-    required = ('crv', JWK.type_field_name, 'x', 'y')
+
+    typ = "EC"
+    __slots__ = ("key",)
+    cryptography_key_types = (ec.EllipticCurvePublicKey, ec.EllipticCurvePrivateKey)
+    required = ("crv", JWK.type_field_name, "x", "y")
     key: josepy.util.ComparableECKey
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        if 'key' in kwargs and not isinstance(
-                kwargs['key'], util.ComparableECKey):
-            kwargs['key'] = util.ComparableECKey(kwargs['key'])
+        if "key" in kwargs and not isinstance(kwargs["key"], util.ComparableECKey):
+            kwargs["key"] = util.ComparableECKey(kwargs["key"])
         super().__init__(*args, **kwargs)
 
     @classmethod
@@ -305,7 +318,7 @@ class JWKEC(JWK):
             if len(binary) != valid_length:
                 raise errors.DeserializationError(
                     f'Expected parameter "{name}" to be {valid_length} bytes '
-                    f'after base64-decoding; got {len(binary)} bytes instead'
+                    f"after base64-decoding; got {len(binary)} bytes instead"
                 )
             return int.from_bytes(binary, byteorder="big")
         except ValueError:  # invalid literal for long() with base 16
@@ -313,22 +326,22 @@ class JWKEC(JWK):
 
     @classmethod
     def _curve_name_to_crv(cls, curve_name: str) -> str:
-        if curve_name == 'secp256r1':
-            return 'P-256'
-        if curve_name == 'secp384r1':
-            return 'P-384'
-        if curve_name == 'secp521r1':
-            return 'P-521'
+        if curve_name == "secp256r1":
+            return "P-256"
+        if curve_name == "secp384r1":
+            return "P-384"
+        if curve_name == "secp521r1":
+            return "P-521"
         raise errors.SerializationError()
 
     @classmethod
     def _crv_to_curve(cls, crv: str) -> ec.EllipticCurve:
         # crv is case-sensitive
-        if crv == 'P-256':
+        if crv == "P-256":
             return ec.SECP256R1()
-        if crv == 'P-384':
+        if crv == "P-384":
             return ec.SECP384R1()
-        if crv == 'P-521':
+        if crv == "P-521":
             return ec.SECP521R1()
         raise errors.DeserializationError()
 
@@ -340,7 +353,7 @@ class JWKEC(JWK):
             return 48
         elif isinstance(curve, ec.SECP521R1):
             return 66
-        raise ValueError(f'Unexpected curve: {curve}')
+        raise ValueError(f"Unexpected curve: {curve}")
 
     def fields_to_partial_json(self) -> Dict[str, Any]:
         params = {}
@@ -349,40 +362,40 @@ class JWKEC(JWK):
         elif isinstance(self.key._wrapped, ec.EllipticCurvePrivateKey):
             private = self.key.private_numbers()
             public = self.key.public_key().public_numbers()
-            params['d'] = private.private_value
+            params["d"] = private.private_value
         else:
             raise errors.SerializationError(
-                'Supplied key is neither of type EllipticCurvePublicKey '
-                'nor EllipticCurvePrivateKey'
+                "Supplied key is neither of type EllipticCurvePublicKey "
+                "nor EllipticCurvePrivateKey"
             )
-        params['x'] = public.x
-        params['y'] = public.y
+        params["x"] = public.x
+        params["y"] = public.y
         params = {
             key: self._encode_param(value, self.expected_length_for_curve(public.curve))
             for key, value in params.items()
         }
-        params['crv'] = self._curve_name_to_crv(public.curve.name)
+        params["crv"] = self._curve_name_to_crv(public.curve.name)
         return params
 
     @classmethod
-    def fields_from_json(cls, jobj: Mapping[str, Any]) -> 'JWKEC':
-        curve = cls._crv_to_curve(jobj['crv'])
+    def fields_from_json(cls, jobj: Mapping[str, Any]) -> "JWKEC":
+        curve = cls._crv_to_curve(jobj["crv"])
         expected_length = cls.expected_length_for_curve(curve)
-        x, y = (cls._decode_param(jobj[n], n, expected_length) for n in ('x', 'y'))
+        x, y = (cls._decode_param(jobj[n], n, expected_length) for n in ("x", "y"))
         public_numbers = ec.EllipticCurvePublicNumbers(x=x, y=y, curve=curve)
 
         # private key
-        if 'd' not in jobj:
+        if "d" not in jobj:
             return cls(key=public_numbers.public_key(default_backend()))
 
         # private key
-        d = cls._decode_param(jobj['d'], 'd', expected_length)
+        d = cls._decode_param(jobj["d"], "d", expected_length)
         key = ec.EllipticCurvePrivateNumbers(d, public_numbers).private_key(default_backend())
         return cls(key=key)
 
-    def public_key(self) -> 'JWKEC':
+    def public_key(self) -> "JWKEC":
         # Unlike RSAPrivateKey, EllipticCurvePrivateKey does not contain public_key()
-        if hasattr(self.key, 'public_key'):
+        if hasattr(self.key, "public_key"):
             key = self.key.public_key()
         else:
             key = self.key.public_numbers().public_key(default_backend())

--- a/src/josepy/jwk.py
+++ b/src/josepy/jwk.py
@@ -62,9 +62,9 @@ class JWK(json_util.TypedJSONObjectWithFields, metaclass=abc.ABCMeta):
         digest.update(
             json.dumps(
                 {k: v for k, v in self.to_json().items() if k in self.required},
-                **self._thumbprint_json_dumps_params,
+                **self._thumbprint_json_dumps_params,  # type: ignore[arg-type]
             ).encode()
-        )  # type: ignore[arg-type]
+        )
         return digest.finalize()
 
     @abc.abstractmethod

--- a/src/josepy/jws.py
+++ b/src/josepy/jws.py
@@ -25,16 +25,16 @@ from josepy import util
 class MediaType:
     """MediaType field encoder/decoder."""
 
-    PREFIX = 'application/'
+    PREFIX = "application/"
     """MIME Media Type and Content Type prefix."""
 
     @classmethod
     def decode(cls, value: str) -> str:
         """Decoder."""
         # 4.1.10
-        if '/' not in value:
-            if ';' in value:
-                raise errors.DeserializationError('Unexpected semi-colon')
+        if "/" not in value:
+            if ";" in value:
+                raise errors.DeserializationError("Unexpected semi-colon")
             return cls.PREFIX + value
         return value
 
@@ -42,9 +42,9 @@ class MediaType:
     def encode(cls, value: str) -> str:
         """Encoder."""
         # 4.1.10
-        if ';' not in value:
+        if ";" not in value:
             assert value.startswith(cls.PREFIX)
-            return value[len(cls.PREFIX):]
+            return value[len(cls.PREFIX) :]
         return value
 
 
@@ -69,41 +69,47 @@ class Header(json_util.JSONObjectWithFields):
     :ivar str cty: Content-Type, inc. :const:`MediaType.PREFIX`.
 
     """
+
     alg: Optional[jwa.JWASignature] = json_util.field(
-        'alg', decoder=jwa.JWASignature.from_json, omitempty=True)
-    jku: Optional[bytes] = json_util.field('jku', omitempty=True)
+        "alg", decoder=jwa.JWASignature.from_json, omitempty=True
+    )
+    jku: Optional[bytes] = json_util.field("jku", omitempty=True)
     jwk: Optional[jwk_mod.JWK] = json_util.field(
-        'jwk', decoder=jwk_mod.JWK.from_json, omitempty=True)
-    kid: Optional[str] = json_util.field('kid', omitempty=True)
-    x5u: Optional[bytes] = json_util.field('x5u', omitempty=True)
-    x5c: Tuple[util.ComparableX509, ...] = json_util.field('x5c', omitempty=True, default=())
-    x5t: Optional[bytes] = json_util.field(
-        'x5t', decoder=json_util.decode_b64jose, omitempty=True)
+        "jwk", decoder=jwk_mod.JWK.from_json, omitempty=True
+    )
+    kid: Optional[str] = json_util.field("kid", omitempty=True)
+    x5u: Optional[bytes] = json_util.field("x5u", omitempty=True)
+    x5c: Tuple[util.ComparableX509, ...] = json_util.field("x5c", omitempty=True, default=())
+    x5t: Optional[bytes] = json_util.field("x5t", decoder=json_util.decode_b64jose, omitempty=True)
     x5tS256: Optional[bytes] = json_util.field(
-        'x5t#S256', decoder=json_util.decode_b64jose, omitempty=True)
-    typ: Optional[MediaType] = json_util.field('typ', encoder=MediaType.encode,
-                                               decoder=MediaType.decode, omitempty=True)
-    cty: Optional[MediaType] = json_util.field('cty', encoder=MediaType.encode,
-                                               decoder=MediaType.decode, omitempty=True)
-    crit: Tuple[Any, ...] = json_util.field('crit', omitempty=True, default=())
+        "x5t#S256", decoder=json_util.decode_b64jose, omitempty=True
+    )
+    typ: Optional[MediaType] = json_util.field(
+        "typ", encoder=MediaType.encode, decoder=MediaType.decode, omitempty=True
+    )
+    cty: Optional[MediaType] = json_util.field(
+        "cty", encoder=MediaType.encode, decoder=MediaType.decode, omitempty=True
+    )
+    crit: Tuple[Any, ...] = json_util.field("crit", omitempty=True, default=())
     _fields: Dict[str, json_util.Field]
 
     def not_omitted(self) -> Dict[str, json_util.Field]:
         """Fields that would not be omitted in the JSON object."""
-        return {name: getattr(self, name)
-                for name, field in self._fields.items()
-                if not field.omit(getattr(self, name))}
+        return {
+            name: getattr(self, name)
+            for name, field in self._fields.items()
+            if not field.omit(getattr(self, name))
+        }
 
-    def __add__(self, other: Any) -> 'Header':
+    def __add__(self, other: Any) -> "Header":
         if not isinstance(other, type(self)):
-            raise TypeError('Header cannot be added to: {0}'.format(
-                type(other)))
+            raise TypeError("Header cannot be added to: {0}".format(type(other)))
 
         not_omitted_self = self.not_omitted()
         not_omitted_other = other.not_omitted()
 
         if set(not_omitted_self).intersection(not_omitted_other):
-            raise TypeError('Addition of overlapping headers not defined')
+            raise TypeError("Addition of overlapping headers not defined")
 
         not_omitted_self.update(not_omitted_other)
         return type(self)(**not_omitted_self)
@@ -120,27 +126,31 @@ class Header(json_util.JSONObjectWithFields):
 
         """
         if self.jwk is None:
-            raise errors.Error('No key found')
+            raise errors.Error("No key found")
         return self.jwk
 
     @crit.decoder  # type: ignore
     def crit(unused_value: Any) -> Any:
-        raise errors.DeserializationError(
-            '"crit" is not supported, please subclass')
+        raise errors.DeserializationError('"crit" is not supported, please subclass')
 
     # x5c does NOT use JOSE Base64 (4.1.6)
 
     @x5c.encoder  # type: ignore
     def x5c(value):
-        return [base64.b64encode(crypto.dump_certificate(
-            crypto.FILETYPE_ASN1, cert.wrapped)) for cert in value]
+        return [
+            base64.b64encode(crypto.dump_certificate(crypto.FILETYPE_ASN1, cert.wrapped))
+            for cert in value
+        ]
 
     @x5c.decoder  # type: ignore
     def x5c(value):
         try:
-            return tuple(util.ComparableX509(crypto.load_certificate(
-                crypto.FILETYPE_ASN1,
-                base64.b64decode(cert))) for cert in value)
+            return tuple(
+                util.ComparableX509(
+                    crypto.load_certificate(crypto.FILETYPE_ASN1, base64.b64decode(cert))
+                )
+                for cert in value
+            )
         except crypto.Error as error:
             raise errors.DeserializationError(error)
 
@@ -155,51 +165,51 @@ class Signature(json_util.JSONObjectWithFields):
     :ivar str signature: The signature.
 
     """
+
     header_cls = Header
     combined: Header
 
-    __slots__ = ('combined',)
-    protected: str = json_util.field('protected', omitempty=True, default='')
+    __slots__ = ("combined",)
+    protected: str = json_util.field("protected", omitempty=True, default="")
     header: Header = json_util.field(
-        'header', omitempty=True, default=header_cls(),
-        decoder=header_cls.from_json)
+        "header", omitempty=True, default=header_cls(), decoder=header_cls.from_json
+    )
     signature: bytes = json_util.field(
-        'signature', decoder=json_util.decode_b64jose,
-        encoder=json_util.encode_b64jose)
+        "signature", decoder=json_util.decode_b64jose, encoder=json_util.encode_b64jose
+    )
 
     @protected.encoder  # type: ignore
     def protected(value: str) -> str:
         # wrong type guess (Signature, not bytes) | pylint: disable=no-member
-        return json_util.encode_b64jose(value.encode('utf-8'))
+        return json_util.encode_b64jose(value.encode("utf-8"))
 
     @protected.decoder  # type: ignore
     def protected(value: str) -> str:
-        return json_util.decode_b64jose(value).decode('utf-8')
+        return json_util.decode_b64jose(value).decode("utf-8")
 
     def __init__(self, **kwargs: Any) -> None:
-        if 'combined' not in kwargs:
+        if "combined" not in kwargs:
             kwargs = self._with_combined(kwargs)
         super().__init__(**kwargs)
         assert self.combined.alg is not None
 
     @classmethod
     def _with_combined(cls, kwargs: Any) -> Dict[str, Any]:
-        assert 'combined' not in kwargs
-        header = kwargs.get('header', cls._fields['header'].default)
-        protected = kwargs.get('protected', cls._fields['protected'].default)
+        assert "combined" not in kwargs
+        header = kwargs.get("header", cls._fields["header"].default)
+        protected = kwargs.get("protected", cls._fields["protected"].default)
 
         if protected:
             combined = header + cls.header_cls.json_loads(protected)
         else:
             combined = header
 
-        kwargs['combined'] = combined
+        kwargs["combined"] = combined
         return kwargs
 
     @classmethod
     def _msg(cls, protected: str, payload: bytes) -> bytes:
-        return (b64.b64encode(protected.encode('utf-8')) + b'.' +
-                b64.b64encode(payload))
+        return b64.b64encode(protected.encode("utf-8")) + b"." + b64.b64encode(payload)
 
     def verify(self, payload: bytes, key: Optional[josepy.JWK] = None) -> bool:
         """Verify.
@@ -212,13 +222,19 @@ class Signature(json_util.JSONObjectWithFields):
         if not self.combined.alg:
             raise josepy.Error("Not signature algorithm defined.")
         return self.combined.alg.verify(
-            key=actual_key.key, sig=self.signature,
-            msg=self._msg(self.protected, payload))
+            key=actual_key.key, sig=self.signature, msg=self._msg(self.protected, payload)
+        )
 
     @classmethod
-    def sign(cls, payload: bytes, key: josepy.JWK, alg: josepy.JWASignature,
-             include_jwk: bool = True, protect: FrozenSet = frozenset(),
-             **kwargs: Any) -> 'Signature':
+    def sign(
+        cls,
+        payload: bytes,
+        key: josepy.JWK,
+        alg: josepy.JWASignature,
+        include_jwk: bool = True,
+        protect: FrozenSet = frozenset(),
+        **kwargs: Any,
+    ) -> "Signature":
         """Sign.
 
         :param bytes payload: Payload to sign.
@@ -231,9 +247,9 @@ class Signature(json_util.JSONObjectWithFields):
         assert isinstance(key, alg.kty)
 
         header_params = kwargs
-        header_params['alg'] = alg
+        header_params["alg"] = alg
         if include_jwk:
-            header_params['jwk'] = key.public_key()
+            header_params["jwk"] = key.public_key()
 
         assert set(header_params).issubset(cls.header_cls._fields)
         assert protect.issubset(cls.header_cls._fields)
@@ -245,7 +261,7 @@ class Signature(json_util.JSONObjectWithFields):
         if protected_params:
             protected = cls.header_cls(**protected_params).json_dumps()
         else:
-            protected = ''
+            protected = ""
 
         header = cls.header_cls(**header_params)
         signature = alg.sign(key.key, cls._msg(protected, payload))
@@ -254,16 +270,16 @@ class Signature(json_util.JSONObjectWithFields):
 
     def fields_to_partial_json(self) -> Dict[str, Any]:
         fields = super().fields_to_partial_json()
-        if not fields['header'].not_omitted():
-            del fields['header']
+        if not fields["header"].not_omitted():
+            del fields["header"]
         return fields
 
     @classmethod
     def fields_from_json(cls, jobj: Mapping[str, Any]) -> Dict[str, Any]:
         fields = super().fields_from_json(jobj)
         fields_with_combined = cls._with_combined(fields)
-        if 'alg' not in fields_with_combined['combined'].not_omitted():
-            raise errors.DeserializationError('alg not present')
+        if "alg" not in fields_with_combined["combined"].not_omitted():
+            raise errors.DeserializationError("alg not present")
         return fields_with_combined
 
 
@@ -274,7 +290,8 @@ class JWS(json_util.JSONObjectWithFields):
     :ivar str signature: JWS Signatures.
 
     """
-    __slots__ = ('payload', 'signatures')
+
+    __slots__ = ("payload", "signatures")
     payload: bytes
     signatures: List[Signature]
 
@@ -285,10 +302,9 @@ class JWS(json_util.JSONObjectWithFields):
         return all(sig.verify(self.payload, key) for sig in self.signatures)
 
     @classmethod
-    def sign(cls, payload: bytes, **kwargs: Any) -> 'JWS':
+    def sign(cls, payload: bytes, **kwargs: Any) -> "JWS":
         """Sign."""
-        return cls(payload=payload, signatures=(
-            cls.signature_cls.sign(payload=payload, **kwargs),))
+        return cls(payload=payload, signatures=(cls.signature_cls.sign(payload=payload, **kwargs),))
 
     @property
     def signature(self) -> Signature:
@@ -308,33 +324,34 @@ class JWS(json_util.JSONObjectWithFields):
         """
         assert len(self.signatures) == 1
 
-        assert 'alg' not in self.signature.header.not_omitted()
+        assert "alg" not in self.signature.header.not_omitted()
         # ... it must be in protected
 
         return (
-            b64.b64encode(self.signature.protected.encode('utf-8')) +
-            b'.' +
-            b64.b64encode(self.payload) +
-            b'.' +
-            b64.b64encode(self.signature.signature))
+            b64.b64encode(self.signature.protected.encode("utf-8"))
+            + b"."
+            + b64.b64encode(self.payload)
+            + b"."
+            + b64.b64encode(self.signature.signature)
+        )
 
     @classmethod
-    def from_compact(cls, compact: bytes) -> 'JWS':
+    def from_compact(cls, compact: bytes) -> "JWS":
         """Compact deserialization.
 
         :param bytes compact:
 
         """
         try:
-            protected, payload, signature = compact.split(b'.')
+            protected, payload, signature = compact.split(b".")
         except ValueError:
             raise errors.DeserializationError(
-                'Compact JWS serialization should comprise of exactly'
-                ' 3 dot-separated components')
+                "Compact JWS serialization should comprise of exactly" " 3 dot-separated components"
+            )
 
         sig = cls.signature_cls(
-            protected=b64.b64decode(protected).decode('utf-8'),
-            signature=b64.b64decode(signature))
+            protected=b64.b64decode(protected).decode("utf-8"), signature=b64.b64decode(signature)
+        )
         return cls(payload=b64.b64decode(payload), signatures=(sig,))
 
     def to_partial_json(self, flat: bool = True) -> Dict[str, Any]:
@@ -343,26 +360,29 @@ class JWS(json_util.JSONObjectWithFields):
 
         if flat and len(self.signatures) == 1:
             ret = self.signatures[0].to_partial_json()
-            ret['payload'] = payload
+            ret["payload"] = payload
             return ret
         else:
             return {
-                'payload': payload,
-                'signatures': self.signatures,
+                "payload": payload,
+                "signatures": self.signatures,
             }
 
     @classmethod
-    def from_json(cls, jobj: Mapping[str, Any]) -> 'JWS':
-        if 'signature' in jobj and 'signatures' in jobj:
-            raise errors.DeserializationError('Flat mixed with non-flat')
-        elif 'signature' in jobj:  # flat
+    def from_json(cls, jobj: Mapping[str, Any]) -> "JWS":
+        if "signature" in jobj and "signatures" in jobj:
+            raise errors.DeserializationError("Flat mixed with non-flat")
+        elif "signature" in jobj:  # flat
             filtered = {key: value for key, value in jobj.items() if key != "payload"}
-            return cls(payload=json_util.decode_b64jose(jobj['payload']),
-                       signatures=(cls.signature_cls.from_json(filtered),))
+            return cls(
+                payload=json_util.decode_b64jose(jobj["payload"]),
+                signatures=(cls.signature_cls.from_json(filtered),),
+            )
         else:
-            return cls(payload=json_util.decode_b64jose(jobj['payload']),
-                       signatures=tuple(cls.signature_cls.from_json(sig)
-                                        for sig in jobj['signatures']))
+            return cls(
+                payload=json_util.decode_b64jose(jobj["payload"]),
+                signatures=tuple(cls.signature_cls.from_json(sig) for sig in jobj["signatures"]),
+            )
 
 
 class CLI:
@@ -376,13 +396,14 @@ class CLI:
         if args.protect is None:
             args.protect = []
         if args.compact:
-            args.protect.append('alg')
+            args.protect.append("alg")
 
-        sig = JWS.sign(payload=sys.stdin.read().encode(), key=key, alg=args.alg,
-                       protect=set(args.protect))
+        sig = JWS.sign(
+            payload=sys.stdin.read().encode(), key=key, alg=args.alg, protect=set(args.protect)
+        )
 
         if args.compact:
-            print(sig.to_compact().decode('utf-8'))
+            print(sig.to_compact().decode("utf-8"))
         else:  # JSON
             print(sig.json_dumps_pretty())
 
@@ -428,28 +449,23 @@ class CLI:
         if args is None:
             args = sys.argv[1:]
         parser = argparse.ArgumentParser()
-        parser.add_argument('--compact', action='store_true')
+        parser.add_argument("--compact", action="store_true")
 
         subparsers = parser.add_subparsers()
-        parser_sign = subparsers.add_parser('sign')
+        parser_sign = subparsers.add_parser("sign")
         parser_sign.set_defaults(func=cls.sign)
-        parser_sign.add_argument(
-            '-k', '--key', type=argparse.FileType('rb'), required=True)
-        parser_sign.add_argument(
-            '-a', '--alg', type=cls._alg_type, default=jwa.RS256)
-        parser_sign.add_argument(
-            '-p', '--protect', action='append', type=cls._header_type)
+        parser_sign.add_argument("-k", "--key", type=argparse.FileType("rb"), required=True)
+        parser_sign.add_argument("-a", "--alg", type=cls._alg_type, default=jwa.RS256)
+        parser_sign.add_argument("-p", "--protect", action="append", type=cls._header_type)
 
-        parser_verify = subparsers.add_parser('verify')
+        parser_verify = subparsers.add_parser("verify")
         parser_verify.set_defaults(func=cls.verify)
-        parser_verify.add_argument(
-            '-k', '--key', type=argparse.FileType('rb'), required=False)
-        parser_verify.add_argument(
-            '--kty', type=cls._kty_type, required=False)
+        parser_verify.add_argument("-k", "--key", type=argparse.FileType("rb"), required=False)
+        parser_verify.add_argument("--kty", type=cls._kty_type, required=False)
 
         parsed = parser.parse_args(args)
         return parsed.func(parsed)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     exit(CLI.run())  # pragma: no cover

--- a/src/josepy/magic_typing.py
+++ b/src/josepy/magic_typing.py
@@ -4,12 +4,14 @@ import sys
 import warnings
 from typing import Any
 
-warnings.warn("josepy.magic_typing is deprecated and will be removed in a future release.",
-              DeprecationWarning)
+warnings.warn(
+    "josepy.magic_typing is deprecated and will be removed in a future release.", DeprecationWarning
+)
 
 
 class TypingClass:
     """Ignore import errors by getting anything"""
+
     def __getattr__(self, name: str) -> Any:
         return None
 

--- a/src/josepy/util.py
+++ b/src/josepy/util.py
@@ -24,8 +24,7 @@ class ComparableX509:
     """
 
     def __init__(self, wrapped: Union[crypto.X509, crypto.X509Req]) -> None:
-        assert isinstance(wrapped, crypto.X509) or isinstance(
-            wrapped, crypto.X509Req)
+        assert isinstance(wrapped, crypto.X509) or isinstance(wrapped, crypto.X509Req)
         self.wrapped = wrapped
 
     def __getattr__(self, name: str) -> Any:
@@ -58,7 +57,7 @@ class ComparableX509:
         return hash((self.__class__, self._dump()))
 
     def __repr__(self) -> str:
-        return '<{0}({1!r})>'.format(self.__class__.__name__, self.wrapped)
+        return "<{0}({1!r})>".format(self.__class__.__name__, self.wrapped)
 
 
 class ComparableKey:
@@ -67,37 +66,45 @@ class ComparableKey:
     See https://github.com/pyca/cryptography/issues/2122.
 
     """
+
     __hash__: Callable[[], int] = NotImplemented
 
-    def __init__(self,
-                 wrapped: Union[
-                     rsa.RSAPrivateKeyWithSerialization,
-                     rsa.RSAPublicKeyWithSerialization,
-                     ec.EllipticCurvePrivateKeyWithSerialization,
-                     ec.EllipticCurvePublicKeyWithSerialization]):
+    def __init__(
+        self,
+        wrapped: Union[
+            rsa.RSAPrivateKeyWithSerialization,
+            rsa.RSAPublicKeyWithSerialization,
+            ec.EllipticCurvePrivateKeyWithSerialization,
+            ec.EllipticCurvePublicKeyWithSerialization,
+        ],
+    ):
         self._wrapped = wrapped
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._wrapped, name)
 
     def __eq__(self, other: Any) -> bool:
-        if (not isinstance(other, self.__class__) or
-                self._wrapped.__class__ is not other._wrapped.__class__):
+        if (
+            not isinstance(other, self.__class__)
+            or self._wrapped.__class__ is not other._wrapped.__class__
+        ):
             return NotImplemented
-        elif hasattr(self._wrapped, 'private_numbers'):
+        elif hasattr(self._wrapped, "private_numbers"):
             return self.private_numbers() == other.private_numbers()
-        elif hasattr(self._wrapped, 'public_numbers'):
+        elif hasattr(self._wrapped, "public_numbers"):
             return self.public_numbers() == other.public_numbers()
         else:
             return NotImplemented
 
     def __repr__(self) -> str:
-        return '<{0}({1!r})>'.format(self.__class__.__name__, self._wrapped)
+        return "<{0}({1!r})>".format(self.__class__.__name__, self._wrapped)
 
-    def public_key(self) -> 'ComparableKey':
+    def public_key(self) -> "ComparableKey":
         """Get wrapped public key."""
-        if isinstance(self._wrapped, (rsa.RSAPublicKeyWithSerialization,
-                                      ec.EllipticCurvePublicKeyWithSerialization)):
+        if isinstance(
+            self._wrapped,
+            (rsa.RSAPublicKeyWithSerialization, ec.EllipticCurvePublicKeyWithSerialization),
+        ):
             return self
 
         return self.__class__(self._wrapped.public_key())
@@ -119,8 +126,9 @@ class ComparableRSAKey(ComparableKey):
         if isinstance(self._wrapped, rsa.RSAPrivateKeyWithSerialization):
             priv = self.private_numbers()
             pub = priv.public_numbers
-            return hash((self.__class__, priv.p, priv.q, priv.dmp1,
-                         priv.dmq1, priv.iqmp, pub.n, pub.e))
+            return hash(
+                (self.__class__, priv.p, priv.q, priv.dmp1, priv.dmq1, priv.iqmp, pub.n, pub.e)
+            )
         elif isinstance(self._wrapped, rsa.RSAPublicKeyWithSerialization):
             pub = self.public_numbers()
             return hash((self.__class__, pub.n, pub.e))
@@ -149,7 +157,7 @@ class ComparableECKey(ComparableKey):
         raise NotImplementedError()
 
 
-GenericImmutableMap = TypeVar('GenericImmutableMap', bound='ImmutableMap')
+GenericImmutableMap = TypeVar("GenericImmutableMap", bound="ImmutableMap")
 
 
 class ImmutableMap(Mapping, Hashable):
@@ -161,9 +169,11 @@ class ImmutableMap(Mapping, Hashable):
     def __init__(self, **kwargs: Any) -> None:
         if set(kwargs) != set(self.__slots__):
             raise TypeError(
-                '__init__() takes exactly the following arguments: {0} '
-                '({1} given)'.format(', '.join(self.__slots__),
-                                     ', '.join(kwargs) if kwargs else 'none'))
+                "__init__() takes exactly the following arguments: {0} "
+                "({1} given)".format(
+                    ", ".join(self.__slots__), ", ".join(kwargs) if kwargs else "none"
+                )
+            )
         for slot in self.__slots__:
             object.__setattr__(self, slot, kwargs.pop(slot))
 
@@ -191,14 +201,16 @@ class ImmutableMap(Mapping, Hashable):
         raise AttributeError("can't set attribute")
 
     def __repr__(self) -> str:
-        return '{0}({1})'.format(self.__class__.__name__, ', '.join(
-            '{0}={1!r}'.format(key, value)
-            for key, value in self.items()))
+        return "{0}({1})".format(
+            self.__class__.__name__,
+            ", ".join("{0}={1!r}".format(key, value) for key, value in self.items()),
+        )
 
 
 class frozendict(Mapping, Hashable):
     """Frozen dictionary."""
-    __slots__ = ('_items', '_keys')
+
+    __slots__ = ("_items", "_keys")
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         items: Mapping
@@ -210,8 +222,8 @@ class frozendict(Mapping, Hashable):
             raise TypeError()
         # TODO: support generators/iterators
 
-        object.__setattr__(self, '_items', items)
-        object.__setattr__(self, '_keys', tuple(sorted(items.keys())))
+        object.__setattr__(self, "_items", items)
+        object.__setattr__(self, "_keys", tuple(sorted(items.keys())))
 
     def __getitem__(self, key: str) -> Any:
         return self._items[key]
@@ -238,8 +250,9 @@ class frozendict(Mapping, Hashable):
         raise AttributeError("can't set attribute")
 
     def __repr__(self) -> str:
-        return 'frozendict({0})'.format(', '.join('{0}={1!r}'.format(
-            key, value) for key, value in self._sorted_items()))
+        return "frozendict({0})".format(
+            ", ".join("{0}={1!r}".format(key, value) for key, value in self._sorted_items())
+        )
 
 
 # This class takes a similar approach to the cryptography project to deprecate attributes
@@ -250,15 +263,19 @@ class _UtilDeprecationModule:
     Internal class delegating to a module, and displaying warnings when attributes
     related to the deprecated "abstractclassmethod" attributes in the josepy.util module.
     """
+
     def __init__(self, module: ModuleType) -> None:
-        self.__dict__['_module'] = module
+        self.__dict__["_module"] = module
 
     def __getattr__(self, attr: str) -> Any:
-        if attr == 'abstractclassmethod':
-            warnings.warn('The abstractclassmethod attribute in josepy.util is deprecated and will '
-                          'be removed soon. Please use the built-in decorators @classmethod and '
-                          '@abc.abstractmethod together instead.',
-                          DeprecationWarning, stacklevel=2)
+        if attr == "abstractclassmethod":
+            warnings.warn(
+                "The abstractclassmethod attribute in josepy.util is deprecated and will "
+                "be removed soon. Please use the built-in decorators @classmethod and "
+                "@abc.abstractmethod together instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         return getattr(self._module, attr)
 
     def __setattr__(self, attr: str, value: Any) -> None:  # pragma: no cover
@@ -268,7 +285,7 @@ class _UtilDeprecationModule:
         delattr(self._module, attr)
 
     def __dir__(self) -> List[str]:  # pragma: no cover
-        return ['_module'] + dir(self._module)
+        return ["_module"] + dir(self._module)
 
 
 # Patching ourselves to warn about deprecation and planned removal of some elements in the module.

--- a/tests/b64_test.py
+++ b/tests/b64_test.py
@@ -6,17 +6,17 @@ import pytest
 
 # https://en.wikipedia.org/wiki/Base64#Examples
 B64_PADDING_EXAMPLES = {
-    b'any carnal pleasure.': (b'YW55IGNhcm5hbCBwbGVhc3VyZS4', b'='),
-    b'any carnal pleasure': (b'YW55IGNhcm5hbCBwbGVhc3VyZQ', b'=='),
-    b'any carnal pleasur': (b'YW55IGNhcm5hbCBwbGVhc3Vy', b''),
-    b'any carnal pleasu': (b'YW55IGNhcm5hbCBwbGVhc3U', b'='),
-    b'any carnal pleas': (b'YW55IGNhcm5hbCBwbGVhcw', b'=='),
+    b"any carnal pleasure.": (b"YW55IGNhcm5hbCBwbGVhc3VyZS4", b"="),
+    b"any carnal pleasure": (b"YW55IGNhcm5hbCBwbGVhc3VyZQ", b"=="),
+    b"any carnal pleasur": (b"YW55IGNhcm5hbCBwbGVhc3Vy", b""),
+    b"any carnal pleasu": (b"YW55IGNhcm5hbCBwbGVhc3U", b"="),
+    b"any carnal pleas": (b"YW55IGNhcm5hbCBwbGVhcw", b"=="),
 }
 
 
 B64_URL_UNSAFE_EXAMPLES = {
-    bytes((251, 239)): b'--8',
-    bytes((255,)) * 2: b'__8',
+    bytes((251, 239)): b"--8",
+    bytes((255,)) * 2: b"__8",
 }
 
 
@@ -26,10 +26,11 @@ class B64EncodeTest:
     @classmethod
     def _call(cls, data: bytes) -> bytes:
         from josepy.b64 import b64encode
+
         return b64encode(data)
 
     def test_empty(self) -> None:
-        assert self._call(b'') == b''
+        assert self._call(b"") == b""
 
     def test_unsafe_url(self) -> None:
         for text, b64 in B64_URL_UNSAFE_EXAMPLES.items():
@@ -42,7 +43,7 @@ class B64EncodeTest:
     def test_unicode_fails_with_type_error(self) -> None:
         with pytest.raises(TypeError):
             # We're purposefully testing with the incorrect type here.
-            self._call(u'some unicode')  # type: ignore
+            self._call("some unicode")  # type: ignore
 
 
 class B64DecodeTest:
@@ -51,6 +52,7 @@ class B64DecodeTest:
     @classmethod
     def _call(cls, data: Union[bytes, str]) -> bytes:
         from josepy.b64 import b64decode
+
         return b64decode(data)
 
     def test_unsafe_url(self) -> None:
@@ -66,11 +68,11 @@ class B64DecodeTest:
             assert self._call(b64 + pad) == text
 
     def test_unicode_with_ascii(self) -> None:
-        assert self._call(u'YQ') == b'a'
+        assert self._call("YQ") == b"a"
 
     def test_non_ascii_unicode_fails(self) -> None:
         with pytest.raises(ValueError):
-            self._call(u'\u0105')
+            self._call("\u0105")
 
     def test_type_error_no_unicode_or_bytes(self) -> None:
         with pytest.raises(TypeError):
@@ -78,5 +80,5 @@ class B64DecodeTest:
             self._call(object())  # type: ignore
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/tests/errors_test.py
+++ b/tests/errors_test.py
@@ -8,12 +8,12 @@ import pytest
 class UnrecognizedTypeErrorTest(unittest.TestCase):
     def setUp(self) -> None:
         from josepy.errors import UnrecognizedTypeError
-        self.error = UnrecognizedTypeError('foo', {'type': 'foo'})
+
+        self.error = UnrecognizedTypeError("foo", {"type": "foo"})
 
     def test_str(self) -> None:
-        assert "foo was not recognized, full message: {'type': 'foo'}" == \
-            str(self.error)
+        assert "foo was not recognized, full message: {'type': 'foo'}" == str(self.error)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/tests/interfaces_test.py
+++ b/tests/interfaces_test.py
@@ -7,7 +7,6 @@ import pytest
 
 
 class JSONDeSerializableTest(unittest.TestCase):
-
     def setUp(self) -> None:
         from josepy.interfaces import JSONDeSerializable
 
@@ -19,7 +18,7 @@ class JSONDeSerializableTest(unittest.TestCase):
                 return self.v
 
             @classmethod
-            def from_json(cls, jobj: Any) -> 'Basic':
+            def from_json(cls, jobj: Any) -> "Basic":
                 return cls(jobj)
 
         class Sequence(JSONDeSerializable):
@@ -31,9 +30,8 @@ class JSONDeSerializableTest(unittest.TestCase):
                 return [self.x, self.y]
 
             @classmethod
-            def from_json(cls, jobj: List[Any]) -> 'Sequence':
-                return cls(
-                    Basic.from_json(jobj[0]), Basic.from_json(jobj[1]))
+            def from_json(cls, jobj: List[Any]) -> "Sequence":
+                return cls(Basic.from_json(jobj[0]), Basic.from_json(jobj[1]))
 
         class Mapping(JSONDeSerializable):
             def __init__(self, x: Any, y: Any) -> None:
@@ -44,60 +42,60 @@ class JSONDeSerializableTest(unittest.TestCase):
                 return {self.x: self.y}
 
             @classmethod
-            def from_json(cls, jobj: Any) -> 'Mapping':
-                return cls('dummy', 'values')  # pragma: no cover
+            def from_json(cls, jobj: Any) -> "Mapping":
+                return cls("dummy", "values")  # pragma: no cover
 
-        self.basic1 = Basic('foo1')
-        self.basic2 = Basic('foo2')
+        self.basic1 = Basic("foo1")
+        self.basic2 = Basic("foo2")
         self.seq = Sequence(self.basic1, self.basic2)
         self.mapping = Mapping(self.basic1, self.basic2)
         self.nested = Basic([[self.basic1]])
-        self.tuple = Basic(('foo',))
+        self.tuple = Basic(("foo",))
 
         self.Basic = Basic
         self.Sequence = Sequence
         self.Mapping = Mapping
 
     def test_to_json_sequence(self) -> None:
-        assert self.seq.to_json() == ['foo1', 'foo2']
+        assert self.seq.to_json() == ["foo1", "foo2"]
 
     def test_to_json_mapping(self) -> None:
-        assert self.mapping.to_json() == {'foo1': 'foo2'}
+        assert self.mapping.to_json() == {"foo1": "foo2"}
 
     def test_to_json_other(self) -> None:
         mock_value = object()
         assert self.Basic(mock_value).to_json() is mock_value
 
     def test_to_json_nested(self) -> None:
-        assert self.nested.to_json() == [['foo1']]
+        assert self.nested.to_json() == [["foo1"]]
 
     def test_to_json(self) -> None:
-        assert self.tuple.to_json() == (('foo', ))
+        assert self.tuple.to_json() == (("foo",))
 
     def test_from_json_not_implemented(self) -> None:
         from josepy.interfaces import JSONDeSerializable
+
         with pytest.raises(TypeError):
-            JSONDeSerializable.from_json('xxx')
+            JSONDeSerializable.from_json("xxx")
 
     def test_json_loads(self) -> None:
         seq = self.Sequence.json_loads('["foo1", "foo2"]')
         assert isinstance(seq, self.Sequence)
         assert isinstance(seq.x, self.Basic)
         assert isinstance(seq.y, self.Basic)
-        assert seq.x.v == 'foo1'
-        assert seq.y.v == 'foo2'
+        assert seq.x.v == "foo1"
+        assert seq.y.v == "foo2"
 
     def test_json_dumps(self) -> None:
         assert '["foo1", "foo2"]' == self.seq.json_dumps()
 
     def test_json_dumps_pretty(self) -> None:
-        assert self.seq.json_dumps_pretty() == \
-            '[\n    "foo1",\n    "foo2"\n]'
+        assert self.seq.json_dumps_pretty() == '[\n    "foo1",\n    "foo2"\n]'
 
     def test_json_dump_default(self) -> None:
         from josepy.interfaces import JSONDeSerializable
 
-        assert 'foo1' == JSONDeSerializable.json_dump_default(self.basic1)
+        assert "foo1" == JSONDeSerializable.json_dump_default(self.basic1)
 
         jobj = JSONDeSerializable.json_dump_default(self.seq)
         assert len(jobj) == 2
@@ -106,10 +104,11 @@ class JSONDeSerializableTest(unittest.TestCase):
 
     def test_json_dump_default_type_error(self) -> None:
         from josepy.interfaces import JSONDeSerializable
+
         with pytest.raises(TypeError):
             # We're purposefully testing with the incorrect type here.
             JSONDeSerializable.json_dump_default(object())  # type: ignore
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/tests/json_util_test.py
+++ b/tests/json_util_test.py
@@ -10,8 +10,8 @@ import test_util
 
 from josepy import errors, interfaces, util
 
-CERT = test_util.load_comparable_cert('cert.pem')
-CSR = test_util.load_comparable_csr('csr.pem')
+CERT = test_util.load_comparable_cert("cert.pem")
+CSR = test_util.load_comparable_csr("csr.pem")
 
 
 class FieldTest(unittest.TestCase):
@@ -29,72 +29,82 @@ class FieldTest(unittest.TestCase):
         from josepy.json_util import JSONObjectWithFields, field
 
         class DummyProperlyTyped(JSONObjectWithFields):
-            type: str = field('type')
-            index: int = field('index')
+            type: str = field("type")
+            index: int = field("index")
 
         with pytest.raises(ValueError):
+
             class DummyImproperlyTyped(JSONObjectWithFields):
-                type = field('type')
-                index: int = field('index')
+                type = field("type")
+                index: int = field("index")
 
     def test_no_omit_boolean(self) -> None:
         from josepy.json_util import Field
+
         for default, omitempty, value in itertools.product(
-                [True, False], [True, False], [True, False]):
+            [True, False], [True, False], [True, False]
+        ):
             assert Field("foo", default=default, omitempty=omitempty).omit(value) is False
 
     def test_descriptors(self) -> None:
         mock_value = mock.MagicMock()
 
         def decoder(unused_value: Any) -> str:
-            return 'd'
+            return "d"
 
         def encoder(unused_value: Any) -> str:
-            return 'e'
+            return "e"
 
         from josepy.json_util import Field
-        field = Field('foo')
+
+        field = Field("foo")
 
         field = field.encoder(encoder)
-        assert 'e' == field.encode(mock_value)
+        assert "e" == field.encode(mock_value)
 
         field = field.decoder(decoder)
-        assert 'e' == field.encode(mock_value)
-        assert 'd' == field.decode(mock_value)
+        assert "e" == field.encode(mock_value)
+        assert "d" == field.decode(mock_value)
 
     def test_default_encoder_is_partial(self) -> None:
         class MockField(interfaces.JSONDeSerializable):
             def to_partial_json(self) -> Dict[str, Any]:
-                return {'foo': 'bar'}  # pragma: no cover
+                return {"foo": "bar"}  # pragma: no cover
 
             @classmethod
-            def from_json(cls, jobj: Mapping[str, Any]) -> 'MockField':
+            def from_json(cls, jobj: Mapping[str, Any]) -> "MockField":
                 return cls()  # pragma: no cover
+
         mock_field = MockField()
 
         from josepy.json_util import Field
+
         assert Field.default_encoder(mock_field) is mock_field
         # in particular...
-        assert 'foo' != Field.default_encoder(mock_field)
+        assert "foo" != Field.default_encoder(mock_field)
 
     def test_default_encoder_passthrough(self) -> None:
         mock_value = mock.MagicMock()
         from josepy.json_util import Field
+
         assert Field.default_encoder(mock_value) is mock_value
 
     def test_default_decoder_list_to_tuple(self) -> None:
         from josepy.json_util import Field
+
         assert (1, 2, 3) == Field.default_decoder([1, 2, 3])
 
     def test_default_decoder_dict_to_frozendict(self) -> None:
         from josepy.json_util import Field
-        obj = Field.default_decoder({'x': 2})
+
+        obj = Field.default_decoder({"x": 2})
         assert isinstance(obj, util.frozendict)
         assert obj == util.frozendict(x=2)
 
     def test_default_decoder_passthrough(self) -> None:
         mock_value = mock.MagicMock()
         from josepy.json_util import Field
+
         assert Field.default_decoder(mock_value) is mock_value
 
 
@@ -103,11 +113,12 @@ class JSONObjectWithFieldsMetaTest(unittest.TestCase):
 
     def setUp(self) -> None:
         from josepy.json_util import Field, JSONObjectWithFieldsMeta
-        self.field = Field('Baz')
-        self.field2 = Field('Baz2')
+
+        self.field = Field("Baz")
+        self.field2 = Field("Baz2")
 
         class A(metaclass=JSONObjectWithFieldsMeta):
-            __slots__ = ('bar',)
+            __slots__ = ("bar",)
             baz = self.field
 
         class B(A):
@@ -121,18 +132,18 @@ class JSONObjectWithFieldsMetaTest(unittest.TestCase):
         self.c_cls = C
 
     def test_fields(self) -> None:
-        assert {'baz': self.field} == self.a_cls._fields
-        assert {'baz': self.field} == self.b_cls._fields
+        assert {"baz": self.field} == self.a_cls._fields
+        assert {"baz": self.field} == self.b_cls._fields
 
     def test_fields_inheritance(self) -> None:
-        assert {'baz': self.field2} == self.c_cls._fields
+        assert {"baz": self.field2} == self.c_cls._fields
 
     def test_slots(self) -> None:
-        assert ('bar', 'baz') == self.a_cls.__slots__
-        assert ('baz',) == self.b_cls.__slots__
+        assert ("bar", "baz") == self.a_cls.__slots__
+        assert ("baz",) == self.b_cls.__slots__
 
     def test_orig_slots(self) -> None:
-        assert ('bar',) == self.a_cls._orig_slots
+        assert ("bar",) == self.a_cls._orig_slots
         assert () == self.b_cls._orig_slots
 
 
@@ -143,11 +154,9 @@ class JSONObjectWithFieldsTest(unittest.TestCase):
         from josepy.json_util import Field, JSONObjectWithFields
 
         class MockJSONObjectWithFields(JSONObjectWithFields):
-            x = Field('x', omitempty=True,
-                      encoder=(lambda x: x * 2),
-                      decoder=(lambda x: x / 2))
-            y = Field('y')
-            z = Field('Z')  # on purpose uppercase
+            x = Field("x", omitempty=True, encoder=(lambda x: x * 2), decoder=(lambda x: x / 2))
+            y = Field("y")
+            z = Field("Z")  # on purpose uppercase
 
             @y.encoder  # type: ignore
             def y(value):
@@ -168,190 +177,203 @@ class JSONObjectWithFieldsTest(unittest.TestCase):
         assert self.mock == self.MockJSONObjectWithFields(y=2, z=3)
 
     def test_encode(self) -> None:
-        assert 10 == self.MockJSONObjectWithFields(
-            x=5, y=0, z=0).encode("x")
+        assert 10 == self.MockJSONObjectWithFields(x=5, y=0, z=0).encode("x")
 
     def test_encode_wrong_field(self) -> None:
         with pytest.raises(errors.Error):
-            self.mock.encode('foo')
+            self.mock.encode("foo")
 
     def test_encode_serialization_error_passthrough(self) -> None:
         with pytest.raises(errors.SerializationError):
             self.MockJSONObjectWithFields(y=500, z=None).encode("y")
 
     def test_fields_to_partial_json_omits_empty(self) -> None:
-        assert self.mock.fields_to_partial_json() == {'y': 2, 'Z': 3}
+        assert self.mock.fields_to_partial_json() == {"y": 2, "Z": 3}
 
     def test_fields_from_json_fills_default_for_empty(self) -> None:
-        assert {'x': None, 'y': 2, 'z': 3} == \
-            self.MockJSONObjectWithFields.fields_from_json({'y': 2, 'Z': 3})
+        assert {"x": None, "y": 2, "z": 3} == self.MockJSONObjectWithFields.fields_from_json(
+            {"y": 2, "Z": 3}
+        )
 
     def test_fields_from_json_fails_on_missing(self) -> None:
         with pytest.raises(errors.DeserializationError):
-            self.MockJSONObjectWithFields.fields_from_json({'y': 0})
+            self.MockJSONObjectWithFields.fields_from_json({"y": 0})
         with pytest.raises(errors.DeserializationError):
-            self.MockJSONObjectWithFields.fields_from_json({'Z': 0})
+            self.MockJSONObjectWithFields.fields_from_json({"Z": 0})
         with pytest.raises(errors.DeserializationError):
-            self.MockJSONObjectWithFields.fields_from_json({'x': 0, 'y': 0})
+            self.MockJSONObjectWithFields.fields_from_json({"x": 0, "y": 0})
         with pytest.raises(errors.DeserializationError):
-            self.MockJSONObjectWithFields.fields_from_json({'x': 0, 'Z': 0})
+            self.MockJSONObjectWithFields.fields_from_json({"x": 0, "Z": 0})
 
     def test_fields_to_partial_json_encoder(self) -> None:
-        assert self.MockJSONObjectWithFields(x=1, y=2, z=3).to_partial_json() == \
-            {'x': 2, 'y': 2, 'Z': 3}
+        assert self.MockJSONObjectWithFields(x=1, y=2, z=3).to_partial_json() == {
+            "x": 2,
+            "y": 2,
+            "Z": 3,
+        }
 
     def test_fields_from_json_decoder(self) -> None:
-        assert {'x': 2, 'y': 2, 'z': 3} == \
-            self.MockJSONObjectWithFields.fields_from_json(
-                {'x': 4, 'y': 2, 'Z': 3})
+        assert {"x": 2, "y": 2, "z": 3} == self.MockJSONObjectWithFields.fields_from_json(
+            {"x": 4, "y": 2, "Z": 3}
+        )
 
     def test_fields_to_partial_json_error_passthrough(self) -> None:
         with pytest.raises(errors.SerializationError):
-            self.MockJSONObjectWithFields(
-                x=1, y=500, z=3).to_partial_json()
+            self.MockJSONObjectWithFields(x=1, y=500, z=3).to_partial_json()
 
     def test_fields_from_json_error_passthrough(self) -> None:
         with pytest.raises(errors.DeserializationError):
-            self.MockJSONObjectWithFields.from_json({'x': 4, 'y': 500, 'Z': 3})
+            self.MockJSONObjectWithFields.from_json({"x": 4, "y": 500, "Z": 3})
 
 
 class DeEncodersTest(unittest.TestCase):
     def setUp(self) -> None:
         self.b64_cert = (
-            u'MIIB3jCCAYigAwIBAgICBTkwDQYJKoZIhvcNAQELBQAwdzELMAkGA1UEBhM'
-            u'CVVMxETAPBgNVBAgMCE1pY2hpZ2FuMRIwEAYDVQQHDAlBbm4gQXJib3IxKz'
-            u'ApBgNVBAoMIlVuaXZlcnNpdHkgb2YgTWljaGlnYW4gYW5kIHRoZSBFRkYxF'
-            u'DASBgNVBAMMC2V4YW1wbGUuY29tMB4XDTE0MTIxMTIyMzQ0NVoXDTE0MTIx'
-            u'ODIyMzQ0NVowdzELMAkGA1UEBhMCVVMxETAPBgNVBAgMCE1pY2hpZ2FuMRI'
-            u'wEAYDVQQHDAlBbm4gQXJib3IxKzApBgNVBAoMIlVuaXZlcnNpdHkgb2YgTW'
-            u'ljaGlnYW4gYW5kIHRoZSBFRkYxFDASBgNVBAMMC2V4YW1wbGUuY29tMFwwD'
-            u'QYJKoZIhvcNAQEBBQADSwAwSAJBAKx1c7RR7R_drnBSQ_zfx1vQLHUbFLh1'
-            u'AQQQ5R8DZUXd36efNK79vukFhN9HFoHZiUvOjm0c-pVE6K-EdE_twuUCAwE'
-            u'AATANBgkqhkiG9w0BAQsFAANBAC24z0IdwIVKSlntksllvr6zJepBH5fMnd'
-            u'fk3XJp10jT6VE-14KNtjh02a56GoraAvJAT5_H67E8GvJ_ocNnB_o'
+            "MIIB3jCCAYigAwIBAgICBTkwDQYJKoZIhvcNAQELBQAwdzELMAkGA1UEBhM"
+            "CVVMxETAPBgNVBAgMCE1pY2hpZ2FuMRIwEAYDVQQHDAlBbm4gQXJib3IxKz"
+            "ApBgNVBAoMIlVuaXZlcnNpdHkgb2YgTWljaGlnYW4gYW5kIHRoZSBFRkYxF"
+            "DASBgNVBAMMC2V4YW1wbGUuY29tMB4XDTE0MTIxMTIyMzQ0NVoXDTE0MTIx"
+            "ODIyMzQ0NVowdzELMAkGA1UEBhMCVVMxETAPBgNVBAgMCE1pY2hpZ2FuMRI"
+            "wEAYDVQQHDAlBbm4gQXJib3IxKzApBgNVBAoMIlVuaXZlcnNpdHkgb2YgTW"
+            "ljaGlnYW4gYW5kIHRoZSBFRkYxFDASBgNVBAMMC2V4YW1wbGUuY29tMFwwD"
+            "QYJKoZIhvcNAQEBBQADSwAwSAJBAKx1c7RR7R_drnBSQ_zfx1vQLHUbFLh1"
+            "AQQQ5R8DZUXd36efNK79vukFhN9HFoHZiUvOjm0c-pVE6K-EdE_twuUCAwE"
+            "AATANBgkqhkiG9w0BAQsFAANBAC24z0IdwIVKSlntksllvr6zJepBH5fMnd"
+            "fk3XJp10jT6VE-14KNtjh02a56GoraAvJAT5_H67E8GvJ_ocNnB_o"
         )
         self.b64_csr = (
-            u'MIIBXTCCAQcCAQAweTELMAkGA1UEBhMCVVMxETAPBgNVBAgMCE1pY2hpZ2F'
-            u'uMRIwEAYDVQQHDAlBbm4gQXJib3IxDDAKBgNVBAoMA0VGRjEfMB0GA1UECw'
-            u'wWVW5pdmVyc2l0eSBvZiBNaWNoaWdhbjEUMBIGA1UEAwwLZXhhbXBsZS5jb'
-            u'20wXDANBgkqhkiG9w0BAQEFAANLADBIAkEArHVztFHtH92ucFJD_N_HW9As'
-            u'dRsUuHUBBBDlHwNlRd3fp580rv2-6QWE30cWgdmJS86ObRz6lUTor4R0T-3'
-            u'C5QIDAQABoCkwJwYJKoZIhvcNAQkOMRowGDAWBgNVHREEDzANggtleGFtcG'
-            u'xlLmNvbTANBgkqhkiG9w0BAQsFAANBAHJH_O6BtC9aGzEVCMGOZ7z9iIRHW'
-            u'Szr9x_bOzn7hLwsbXPAgO1QxEwL-X-4g20Gn9XBE1N9W6HCIEut2d8wACg'
+            "MIIBXTCCAQcCAQAweTELMAkGA1UEBhMCVVMxETAPBgNVBAgMCE1pY2hpZ2F"
+            "uMRIwEAYDVQQHDAlBbm4gQXJib3IxDDAKBgNVBAoMA0VGRjEfMB0GA1UECw"
+            "wWVW5pdmVyc2l0eSBvZiBNaWNoaWdhbjEUMBIGA1UEAwwLZXhhbXBsZS5jb"
+            "20wXDANBgkqhkiG9w0BAQEFAANLADBIAkEArHVztFHtH92ucFJD_N_HW9As"
+            "dRsUuHUBBBDlHwNlRd3fp580rv2-6QWE30cWgdmJS86ObRz6lUTor4R0T-3"
+            "C5QIDAQABoCkwJwYJKoZIhvcNAQkOMRowGDAWBgNVHREEDzANggtleGFtcG"
+            "xlLmNvbTANBgkqhkiG9w0BAQsFAANBAHJH_O6BtC9aGzEVCMGOZ7z9iIRHW"
+            "Szr9x_bOzn7hLwsbXPAgO1QxEwL-X-4g20Gn9XBE1N9W6HCIEut2d8wACg"
         )
 
     def test_encode_b64jose(self) -> None:
         from josepy.json_util import encode_b64jose
-        encoded = encode_b64jose(b'x')
+
+        encoded = encode_b64jose(b"x")
         assert isinstance(encoded, str)
-        assert u'eA' == encoded
+        assert "eA" == encoded
 
     def test_decode_b64jose(self) -> None:
         from josepy.json_util import decode_b64jose
-        decoded = decode_b64jose(u'eA')
+
+        decoded = decode_b64jose("eA")
         assert isinstance(decoded, bytes)
-        assert b'x' == decoded
+        assert b"x" == decoded
 
     def test_decode_b64jose_padding_error(self) -> None:
         from josepy.json_util import decode_b64jose
+
         with pytest.raises(errors.DeserializationError):
-            decode_b64jose(u'x')
+            decode_b64jose("x")
 
     def test_decode_b64jose_size(self) -> None:
         from josepy.json_util import decode_b64jose
-        assert b'foo' == decode_b64jose(u'Zm9v', size=3)
+
+        assert b"foo" == decode_b64jose("Zm9v", size=3)
         with pytest.raises(errors.DeserializationError):
-            decode_b64jose(u'Zm9v', size=2)
+            decode_b64jose("Zm9v", size=2)
         with pytest.raises(errors.DeserializationError):
-            decode_b64jose(u'Zm9v', size=4)
+            decode_b64jose("Zm9v", size=4)
 
     def test_decode_b64jose_minimum_size(self) -> None:
         from josepy.json_util import decode_b64jose
-        assert b'foo' == decode_b64jose(u'Zm9v', size=3, minimum=True)
-        assert b'foo' == decode_b64jose(u'Zm9v', size=2, minimum=True)
+
+        assert b"foo" == decode_b64jose("Zm9v", size=3, minimum=True)
+        assert b"foo" == decode_b64jose("Zm9v", size=2, minimum=True)
         with pytest.raises(errors.DeserializationError):
-            decode_b64jose(u'Zm9v', size=4, minimum=True)
+            decode_b64jose("Zm9v", size=4, minimum=True)
 
     def test_encode_hex16(self) -> None:
         from josepy.json_util import encode_hex16
-        encoded = encode_hex16(b'foo')
-        assert u'666f6f' == encoded
+
+        encoded = encode_hex16(b"foo")
+        assert "666f6f" == encoded
         assert isinstance(encoded, str)
 
     def test_decode_hex16(self) -> None:
         from josepy.json_util import decode_hex16
-        decoded = decode_hex16(u'666f6f')
-        assert b'foo' == decoded
+
+        decoded = decode_hex16("666f6f")
+        assert b"foo" == decoded
         assert isinstance(decoded, bytes)
 
     def test_decode_hex16_minimum_size(self) -> None:
         from josepy.json_util import decode_hex16
-        assert b'foo' == decode_hex16(u'666f6f', size=3, minimum=True)
-        assert b'foo' == decode_hex16(u'666f6f', size=2, minimum=True)
+
+        assert b"foo" == decode_hex16("666f6f", size=3, minimum=True)
+        assert b"foo" == decode_hex16("666f6f", size=2, minimum=True)
         with pytest.raises(errors.DeserializationError):
-            decode_hex16(u'666f6f', size=4, minimum=True)
+            decode_hex16("666f6f", size=4, minimum=True)
 
     def test_decode_hex16_odd_length(self) -> None:
         from josepy.json_util import decode_hex16
+
         with pytest.raises(errors.DeserializationError):
-            decode_hex16(u'x')
+            decode_hex16("x")
 
     def test_encode_cert(self) -> None:
         from josepy.json_util import encode_cert
+
         assert self.b64_cert == encode_cert(CERT)
 
     def test_decode_cert(self) -> None:
         from josepy.json_util import decode_cert
+
         cert = decode_cert(self.b64_cert)
         assert isinstance(cert, util.ComparableX509)
         assert cert == CERT
         with pytest.raises(errors.DeserializationError):
-            decode_cert(u'')
+            decode_cert("")
 
     def test_encode_csr(self) -> None:
         from josepy.json_util import encode_csr
+
         assert self.b64_csr == encode_csr(CSR)
 
     def test_decode_csr(self) -> None:
         from josepy.json_util import decode_csr
+
         csr = decode_csr(self.b64_csr)
         assert isinstance(csr, util.ComparableX509)
         assert csr == CSR
         with pytest.raises(errors.DeserializationError):
-            decode_csr(u'')
+            decode_csr("")
 
 
 class TypedJSONObjectWithFieldsTest(unittest.TestCase):
-
     def setUp(self) -> None:
         from josepy.json_util import TypedJSONObjectWithFields
 
         class MockParentTypedJSONObjectWithFields(TypedJSONObjectWithFields):
             TYPES = {}
-            type_field_name = 'type'
+            type_field_name = "type"
 
         @MockParentTypedJSONObjectWithFields.register
-        class MockTypedJSONObjectWithFields(
-                MockParentTypedJSONObjectWithFields):
+        class MockTypedJSONObjectWithFields(MockParentTypedJSONObjectWithFields):
             foo: str
-            typ = 'test'
-            __slots__ = ('foo',)
+            typ = "test"
+            __slots__ = ("foo",)
 
             @classmethod
             def fields_from_json(cls, jobj: Mapping[str, Any]) -> Dict[str, Any]:
-                return {'foo': jobj['foo']}
+                return {"foo": jobj["foo"]}
 
             def fields_to_partial_json(self) -> Any:
-                return {'foo': self.foo}
+                return {"foo": self.foo}
 
         self.parent_cls = MockParentTypedJSONObjectWithFields
-        self.msg = MockTypedJSONObjectWithFields(foo='bar')
+        self.msg = MockTypedJSONObjectWithFields(foo="bar")
 
     def test_to_partial_json(self) -> None:
         assert self.msg.to_partial_json() == {
-            'type': 'test',
-            'foo': 'bar',
+            "type": "test",
+            "foo": "bar",
         }
 
     def test_from_json_non_dict_fails(self) -> None:
@@ -366,12 +388,11 @@ class TypedJSONObjectWithFieldsTest(unittest.TestCase):
 
     def test_from_json_unknown_type_fails(self) -> None:
         with pytest.raises(errors.UnrecognizedTypeError):
-            self.parent_cls.from_json({'type': 'bar'})
+            self.parent_cls.from_json({"type": "bar"})
 
     def test_from_json_returns_obj(self) -> None:
-        assert {'foo': 'bar'} == self.parent_cls.from_json(
-            {'type': 'test', 'foo': 'bar'})
+        assert {"foo": "bar"} == self.parent_cls.from_json({"type": "test", "foo": "bar"})
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/tests/jwa_test.py
+++ b/tests/jwa_test.py
@@ -186,12 +186,18 @@ class JWAECTest(unittest.TestCase):
 
         key = JWK.from_json(
             {
-                "d": "Af9KP6DqLRbtit6NS_LRIaCP_-NdC5l5R2ugbILdfpv6dS9R4wUPNxiGw"
-                "-vVWumA56Yo1oBnEm8ZdR4W-u1lPHw5",
-                "x": "AD4i4STyJ07iZJkHkpKEOuICpn6IHknzwAlrf-1w1a5dqOsRe30EECSN4vFxae"
-                "AmtdBSCKBwCq7h1q4bPgMrMUvF",
-                "y": "AHAlXxrabjcx_yBxGObnm_DkEQMJK1E69OHY3x3VxF5VXoKc93CG4GLoaPvphZQv"
-                "Znt5EfExQoPktwOMIVhBHaFR",
+                "d": (
+                    "Af9KP6DqLRbtit6NS_LRIaCP_-NdC5l5R2ugbILdfpv6dS9R4wUPNxiGw"
+                    "-vVWumA56Yo1oBnEm8ZdR4W-u1lPHw5"
+                ),
+                "x": (
+                    "AD4i4STyJ07iZJkHkpKEOuICpn6IHknzwAlrf-1w1a5dqOsRe30EECSN4vFxae"
+                    "AmtdBSCKBwCq7h1q4bPgMrMUvF"
+                ),
+                "y": (
+                    "AHAlXxrabjcx_yBxGObnm_DkEQMJK1E69OHY3x3VxF5VXoKc93CG4GLoaPvphZQv"
+                    "Znt5EfExQoPktwOMIVhBHaFR"
+                ),
                 "crv": "P-521",
                 "kty": "EC",
             }

--- a/tests/jwa_test.py
+++ b/tests/jwa_test.py
@@ -9,12 +9,12 @@ import test_util
 
 from josepy import errors
 
-RSA256_KEY = test_util.load_rsa_private_key('rsa256_key.pem')
-RSA512_KEY = test_util.load_rsa_private_key('rsa512_key.pem')
-RSA1024_KEY = test_util.load_rsa_private_key('rsa1024_key.pem')
-EC_P256_KEY = test_util.load_ec_private_key('ec_p256_key.pem')
-EC_P384_KEY = test_util.load_ec_private_key('ec_p384_key.pem')
-EC_P521_KEY = test_util.load_ec_private_key('ec_p521_key.pem')
+RSA256_KEY = test_util.load_rsa_private_key("rsa256_key.pem")
+RSA512_KEY = test_util.load_rsa_private_key("rsa512_key.pem")
+RSA1024_KEY = test_util.load_rsa_private_key("rsa1024_key.pem")
+EC_P256_KEY = test_util.load_ec_private_key("ec_p256_key.pem")
+EC_P384_KEY = test_util.load_ec_private_key("ec_p384_key.pem")
+EC_P521_KEY = test_util.load_ec_private_key("ec_p521_key.pem")
 
 
 class JWASignatureTest(unittest.TestCase):
@@ -30,8 +30,8 @@ class JWASignatureTest(unittest.TestCase):
             def verify(self, key: Any, msg: bytes, sig: bytes) -> bool:
                 raise NotImplementedError()  # pragma: no cover
 
-        self.Sig1 = MockSig('Sig1')
-        self.Sig2 = MockSig('Sig2')
+        self.Sig1 = MockSig("Sig1")
+        self.Sig2 = MockSig("Sig2")
 
     def test_eq(self) -> None:
         assert self.Sig1 == self.Sig1
@@ -43,100 +43,107 @@ class JWASignatureTest(unittest.TestCase):
         assert self.Sig1 != 5
 
     def test_repr(self) -> None:
-        assert 'Sig1' == repr(self.Sig1)
-        assert 'Sig2' == repr(self.Sig2)
+        assert "Sig1" == repr(self.Sig1)
+        assert "Sig2" == repr(self.Sig2)
 
     def test_to_partial_json(self) -> None:
-        assert self.Sig1.to_partial_json() == 'Sig1'
-        assert self.Sig2.to_partial_json() == 'Sig2'
+        assert self.Sig1.to_partial_json() == "Sig1"
+        assert self.Sig2.to_partial_json() == "Sig2"
 
     def test_from_json(self) -> None:
         from josepy.jwa import RS256, JWASignature
-        assert JWASignature.from_json('RS256') is RS256
+
+        assert JWASignature.from_json("RS256") is RS256
 
 
 class JWAHSTest(unittest.TestCase):
-
     def test_it(self) -> None:
         from josepy.jwa import HS256
+
         sig = (
             b"\xceR\xea\xcd\x94\xab\xcf\xfb\xe0\xacA.:\x1a'\x08i\xe2\xc4"
             b"\r\x85+\x0e\x85\xaeUZ\xd4\xb3\x97zO"
         )
-        assert HS256.sign(b'some key', b'foo') == sig
-        assert HS256.verify(b'some key', b'foo', sig) is True
-        assert HS256.verify(b'some key', b'foo', sig + b'!') is False
+        assert HS256.sign(b"some key", b"foo") == sig
+        assert HS256.verify(b"some key", b"foo", sig) is True
+        assert HS256.verify(b"some key", b"foo", sig + b"!") is False
 
 
 class JWARSTest(unittest.TestCase):
-
     def test_sign_no_private_part(self) -> None:
         from josepy.jwa import RS256
+
         with pytest.raises(errors.Error):
-            RS256.sign(RSA512_KEY.public_key(), b'foo')
+            RS256.sign(RSA512_KEY.public_key(), b"foo")
 
     def test_sign_key_too_small(self) -> None:
         from josepy.jwa import PS256, RS256
+
         with pytest.raises(errors.Error):
-            RS256.sign(RSA256_KEY, b'foo')
+            RS256.sign(RSA256_KEY, b"foo")
         with pytest.raises(errors.Error):
-            PS256.sign(RSA256_KEY, b'foo')
+            PS256.sign(RSA256_KEY, b"foo")
 
     def test_rs(self) -> None:
         from josepy.jwa import RS256
+
         sig = (
-            b'|\xc6\xb2\xa4\xab(\x87\x99\xfa*:\xea\xf8\xa0N&}\x9f\x0f\xc0O'
+            b"|\xc6\xb2\xa4\xab(\x87\x99\xfa*:\xea\xf8\xa0N&}\x9f\x0f\xc0O"
             b'\xc6t\xa3\xe6\xfa\xbb"\x15Y\x80Y\xe0\x81\xb8\x88)\xba\x0c\x9c'
-            b'\xa4\x99\x1e\x19&\xd8\xc7\x99S\x97\xfc\x85\x0cOV\xe6\x07\x99'
-            b'\xd2\xb9.>}\xfd'
+            b"\xa4\x99\x1e\x19&\xd8\xc7\x99S\x97\xfc\x85\x0cOV\xe6\x07\x99"
+            b"\xd2\xb9.>}\xfd"
         )
-        assert RS256.sign(RSA512_KEY, b'foo') == sig
-        assert RS256.verify(RSA512_KEY.public_key(), b'foo', sig) is True
-        assert RS256.verify(
-            RSA512_KEY.public_key(), b'foo', sig + b'!') is False
+        assert RS256.sign(RSA512_KEY, b"foo") == sig
+        assert RS256.verify(RSA512_KEY.public_key(), b"foo", sig) is True
+        assert RS256.verify(RSA512_KEY.public_key(), b"foo", sig + b"!") is False
 
     def test_ps(self) -> None:
         from josepy.jwa import PS256
-        sig = PS256.sign(RSA1024_KEY, b'foo')
-        assert PS256.verify(RSA1024_KEY.public_key(), b'foo', sig) is True
-        assert PS256.verify(
-            RSA1024_KEY.public_key(), b'foo', sig + b'!') is False
+
+        sig = PS256.sign(RSA1024_KEY, b"foo")
+        assert PS256.verify(RSA1024_KEY.public_key(), b"foo", sig) is True
+        assert PS256.verify(RSA1024_KEY.public_key(), b"foo", sig + b"!") is False
 
     def test_sign_new_api(self) -> None:
         from josepy.jwa import RS256
+
         key = mock.MagicMock()
         RS256.sign(key, b"message")
         assert key.sign.called is True
 
     def test_verify_new_api(self) -> None:
         from josepy.jwa import RS256
+
         key = mock.MagicMock()
         RS256.verify(key, b"message", b"signature")
         assert key.verify.called is True
 
 
 class JWAECTest(unittest.TestCase):
-
     def test_sign_no_private_part(self) -> None:
         from josepy.jwa import ES256
+
         with pytest.raises(errors.Error):
-            ES256.sign(EC_P256_KEY.public_key(), b'foo')
+            ES256.sign(EC_P256_KEY.public_key(), b"foo")
 
     def test_es256_sign_and_verify(self) -> None:
         from josepy.jwa import ES256
-        message = b'foo'
+
+        message = b"foo"
         signature = ES256.sign(EC_P256_KEY, message)
         assert ES256.verify(EC_P256_KEY.public_key(), message, signature) is True
 
     def test_es384_sign_and_verify(self) -> None:
         from josepy.jwa import ES384
-        message = b'foo'
+
+        message = b"foo"
         signature = ES384.sign(EC_P384_KEY, message)
         assert ES384.verify(EC_P384_KEY.public_key(), message, signature) is True
 
     def test_verify_with_wrong_jwa(self) -> None:
         from josepy.jwa import ES256, ES384
-        message = b'foo'
+
+        message = b"foo"
         signature = ES256.sign(EC_P256_KEY, message)
         assert ES384.verify(EC_P384_KEY.public_key(), message, signature) is False
 
@@ -146,7 +153,7 @@ class JWAECTest(unittest.TestCase):
 
         from josepy.jwa import ES256
 
-        message = b'foo'
+        message = b"foo"
         signature = ES256.sign(EC_P256_KEY, message)
         different_key = ec.generate_private_key(ec.SECP256R1(), default_backend())
         assert ES256.verify(different_key.public_key(), message, signature) is False
@@ -155,6 +162,7 @@ class JWAECTest(unittest.TestCase):
         from cryptography.hazmat.primitives.asymmetric.ec import SECP256R1
 
         from josepy.jwa import ES256
+
         key = mock.MagicMock(curve=SECP256R1())
         with mock.patch("josepy.jwa.decode_dss_signature") as decode_patch:
             decode_patch.return_value = (0, 0)
@@ -167,24 +175,27 @@ class JWAECTest(unittest.TestCase):
         from cryptography.hazmat.primitives.asymmetric.ec import SECP256R1
 
         from josepy.jwa import ES256
+
         key = mock.MagicMock(key_size=256, curve=SECP256R1())
-        ES256.verify(key, b"message", b'\x00' * math.ceil(key.key_size / 8) * 2)
+        ES256.verify(key, b"message", b"\x00" * math.ceil(key.key_size / 8) * 2)
         assert key.verify.called is True
 
     def test_signature_size(self) -> None:
         from josepy.jwa import ES512
         from josepy.jwk import JWK
+
         key = JWK.from_json(
             {
-                'd': 'Af9KP6DqLRbtit6NS_LRIaCP_-NdC5l5R2ugbILdfpv6dS9R4wUPNxiGw'
-                     '-vVWumA56Yo1oBnEm8ZdR4W-u1lPHw5',
-                'x': 'AD4i4STyJ07iZJkHkpKEOuICpn6IHknzwAlrf-1w1a5dqOsRe30EECSN4vFxae'
-                     'AmtdBSCKBwCq7h1q4bPgMrMUvF',
-                'y': 'AHAlXxrabjcx_yBxGObnm_DkEQMJK1E69OHY3x3VxF5VXoKc93CG4GLoaPvphZQv'
-                     'Znt5EfExQoPktwOMIVhBHaFR',
-                'crv': 'P-521',
-                'kty': 'EC'
-            })
+                "d": "Af9KP6DqLRbtit6NS_LRIaCP_-NdC5l5R2ugbILdfpv6dS9R4wUPNxiGw"
+                "-vVWumA56Yo1oBnEm8ZdR4W-u1lPHw5",
+                "x": "AD4i4STyJ07iZJkHkpKEOuICpn6IHknzwAlrf-1w1a5dqOsRe30EECSN4vFxae"
+                "AmtdBSCKBwCq7h1q4bPgMrMUvF",
+                "y": "AHAlXxrabjcx_yBxGObnm_DkEQMJK1E69OHY3x3VxF5VXoKc93CG4GLoaPvphZQv"
+                "Znt5EfExQoPktwOMIVhBHaFR",
+                "crv": "P-521",
+                "kty": "EC",
+            }
+        )
         with mock.patch("josepy.jwa.decode_dss_signature") as decode_patch:
             decode_patch.return_value = (0, 0)
             assert isinstance(key, JWK)
@@ -192,5 +203,5 @@ class JWAECTest(unittest.TestCase):
             assert len(sig) == 2 * 66
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/tests/jwk_test.py
+++ b/tests/jwk_test.py
@@ -16,12 +16,12 @@ if TYPE_CHECKING:
 else:
     Protocol = object
 
-DSA_PEM = test_util.load_vector('dsa512_key.pem')
-RSA256_KEY = test_util.load_rsa_private_key('rsa256_key.pem')
-RSA512_KEY = test_util.load_rsa_private_key('rsa512_key.pem')
-EC_P256_KEY = test_util.load_ec_private_key('ec_p256_key.pem')
-EC_P384_KEY = test_util.load_ec_private_key('ec_p384_key.pem')
-EC_P521_KEY = test_util.load_ec_private_key('ec_p521_key.pem')
+DSA_PEM = test_util.load_vector("dsa512_key.pem")
+RSA256_KEY = test_util.load_rsa_private_key("rsa256_key.pem")
+RSA512_KEY = test_util.load_rsa_private_key("rsa512_key.pem")
+EC_P256_KEY = test_util.load_ec_private_key("ec_p256_key.pem")
+EC_P384_KEY = test_util.load_ec_private_key("ec_p384_key.pem")
+EC_P521_KEY = test_util.load_ec_private_key("ec_p521_key.pem")
 
 
 class JWKTest(unittest.TestCase):
@@ -29,17 +29,20 @@ class JWKTest(unittest.TestCase):
 
     def test_load(self) -> None:
         from josepy.jwk import JWK
+
         with pytest.raises(errors.Error):
             JWK.load(DSA_PEM)
 
     def test_load_subclass_wrong_type(self) -> None:
         from josepy.jwk import JWKRSA
+
         with pytest.raises(errors.Error):
             JWKRSA.load(DSA_PEM)
 
 
 class JWKSubclassTest(Protocol):
     from josepy.jwk import JWK
+
     jwk: JWK
     thumbprint: bytes
 
@@ -59,29 +62,35 @@ class JWKTestBaseMixin:
 class JWKOctTest(unittest.TestCase, JWKTestBaseMixin):
     """Tests for josepy.jwk.JWKOct."""
 
-    thumbprint = (b"\xf3\xe7\xbe\xa8`\xd2\xdap\xe9}\x9c\xce>"
-                  b"\xd0\xfcI\xbe\xcd\x92'\xd4o\x0e\xf41\xea"
-                  b"\x8e(\x8a\xb2i\x1c")
+    thumbprint = (
+        b"\xf3\xe7\xbe\xa8`\xd2\xdap\xe9}\x9c\xce>"
+        b"\xd0\xfcI\xbe\xcd\x92'\xd4o\x0e\xf41\xea"
+        b"\x8e(\x8a\xb2i\x1c"
+    )
 
     def setUp(self) -> None:
         from josepy.jwk import JWKOct
-        self.jwk = JWKOct(key=b'foo')
-        self.jobj = {'kty': 'oct', 'k': json_util.encode_b64jose(b'foo')}
+
+        self.jwk = JWKOct(key=b"foo")
+        self.jobj = {"kty": "oct", "k": json_util.encode_b64jose(b"foo")}
 
     def test_to_partial_json(self) -> None:
         assert self.jwk.to_partial_json() == self.jobj
 
     def test_from_json(self) -> None:
         from josepy.jwk import JWKOct
+
         assert self.jwk == JWKOct.from_json(self.jobj)
 
     def test_from_json_hashable(self) -> None:
         from josepy.jwk import JWKOct
+
         hash(JWKOct.from_json(self.jobj))
 
     def test_load(self) -> None:
         from josepy.jwk import JWKOct
-        assert self.jwk == JWKOct.load(b'foo')
+
+        assert self.jwk == JWKOct.load(b"foo")
 
     def test_public_key(self) -> None:
         assert self.jwk.public_key() is self.jwk
@@ -90,38 +99,42 @@ class JWKOctTest(unittest.TestCase, JWKTestBaseMixin):
 class JWKRSATest(unittest.TestCase, JWKTestBaseMixin):
     """Tests for josepy.jwk.JWKRSA."""
 
-    thumbprint = (b'\x83K\xdc#3\x98\xca\x98\xed\xcb\x80\x80<\x0c'
-                  b'\xf0\x95\xb9H\xb2*l\xbd$\xe5&|O\x91\xd4 \xb0Y')
+    thumbprint = (
+        b"\x83K\xdc#3\x98\xca\x98\xed\xcb\x80\x80<\x0c"
+        b"\xf0\x95\xb9H\xb2*l\xbd$\xe5&|O\x91\xd4 \xb0Y"
+    )
 
     def setUp(self) -> None:
         from josepy.jwk import JWKRSA
+
         self.jwk256 = JWKRSA(key=RSA256_KEY.public_key())
         self.jwk256json = {
-            'kty': 'RSA',
-            'e': 'AQAB',
-            'n': 'm2Fylv-Uz7trgTW8EBHP3FQSMeZs2GNQ6VRo1sIVJEk',
+            "kty": "RSA",
+            "e": "AQAB",
+            "n": "m2Fylv-Uz7trgTW8EBHP3FQSMeZs2GNQ6VRo1sIVJEk",
         }
         self.jwk256_not_comparable = JWKRSA(key=RSA256_KEY.public_key()._wrapped)
         self.jwk512 = JWKRSA(key=RSA512_KEY.public_key())
         self.jwk512json = {
-            'kty': 'RSA',
-            'e': 'AQAB',
-            'n': 'rHVztFHtH92ucFJD_N_HW9AsdRsUuHUBBBDlHwNlRd3fp5'
-                 '80rv2-6QWE30cWgdmJS86ObRz6lUTor4R0T-3C5Q',
+            "kty": "RSA",
+            "e": "AQAB",
+            "n": "rHVztFHtH92ucFJD_N_HW9AsdRsUuHUBBBDlHwNlRd3fp5"
+            "80rv2-6QWE30cWgdmJS86ObRz6lUTor4R0T-3C5Q",
         }
         self.private = JWKRSA(key=RSA256_KEY)
         self.private_json_small = self.jwk256json.copy()
-        self.private_json_small['d'] = (
-            'lPQED_EPTV0UIBfNI3KP2d9Jlrc2mrMllmf946bu-CE')
+        self.private_json_small["d"] = "lPQED_EPTV0UIBfNI3KP2d9Jlrc2mrMllmf946bu-CE"
         self.private_json = self.jwk256json.copy()
-        self.private_json.update({
-            'd': 'lPQED_EPTV0UIBfNI3KP2d9Jlrc2mrMllmf946bu-CE',
-            'p': 'zUVNZn4lLLBD1R6NE8TKNQ',
-            'q': 'wcfKfc7kl5jfqXArCRSURQ',
-            'dp': 'CWJFq43QvT5Bm5iN8n1okQ',
-            'dq': 'bHh2u7etM8LKKCF2pY2UdQ',
-            'qi': 'oi45cEkbVoJjAbnQpFY87Q',
-        })
+        self.private_json.update(
+            {
+                "d": "lPQED_EPTV0UIBfNI3KP2d9Jlrc2mrMllmf946bu-CE",
+                "p": "zUVNZn4lLLBD1R6NE8TKNQ",
+                "q": "wcfKfc7kl5jfqXArCRSURQ",
+                "dp": "CWJFq43QvT5Bm5iN8n1okQ",
+                "dq": "bHh2u7etM8LKKCF2pY2UdQ",
+                "qi": "oi45cEkbVoJjAbnQpFY87Q",
+            }
+        )
         self.jwk = self.private
 
     def test_init_auto_comparable(self) -> None:
@@ -132,7 +145,7 @@ class JWKRSATest(unittest.TestCase, JWKTestBaseMixin):
         from josepy.jwk import JWKRSA
 
         # TODO: move encode/decode _param to separate class
-        assert 'AA' == JWKRSA._encode_param(0)
+        assert "AA" == JWKRSA._encode_param(0)
 
     def test_equals(self) -> None:
         assert self.jwk256 == self.jwk256
@@ -144,8 +157,8 @@ class JWKRSATest(unittest.TestCase, JWKTestBaseMixin):
 
     def test_load(self) -> None:
         from josepy.jwk import JWKRSA
-        assert self.private == JWKRSA.load(
-            test_util.load_vector('rsa256_key.pem'))
+
+        assert self.private == JWKRSA.load(test_util.load_vector("rsa256_key.pem"))
 
     def test_public_key(self) -> None:
         assert self.jwk256 == self.private.public_key()
@@ -157,86 +170,101 @@ class JWKRSATest(unittest.TestCase, JWKTestBaseMixin):
 
     def test_from_json(self) -> None:
         from josepy.jwk import JWK
+
         assert self.jwk256 == JWK.from_json(self.jwk256json)
         assert self.jwk512 == JWK.from_json(self.jwk512json)
         assert self.private == JWK.from_json(self.private_json)
 
     def test_from_json_private_small(self) -> None:
         from josepy.jwk import JWK
+
         assert self.private == JWK.from_json(self.private_json_small)
 
     def test_from_json_missing_one_additional(self) -> None:
         from josepy.jwk import JWK
-        del self.private_json['q']
+
+        del self.private_json["q"]
         with pytest.raises(errors.Error):
             JWK.from_json(self.private_json)
 
     def test_from_json_hashable(self) -> None:
         from josepy.jwk import JWK
+
         hash(JWK.from_json(self.jwk256json))
 
     def test_from_json_non_schema_errors(self) -> None:
         # valid against schema, but still failing
         from josepy.jwk import JWK
+
         with pytest.raises(errors.DeserializationError):
-            JWK.from_json({'kty': 'RSA', 'e': 'AQAB', 'n': ''})
+            JWK.from_json({"kty": "RSA", "e": "AQAB", "n": ""})
         with pytest.raises(errors.DeserializationError):
-            JWK.from_json({'kty': 'RSA', 'e': 'AQAB', 'n': '1'})
+            JWK.from_json({"kty": "RSA", "e": "AQAB", "n": "1"})
 
     def test_thumbprint_go_jose(self) -> None:
         # https://github.com/square/go-jose/blob/4ddd71883fa547d37fbf598071f04512d8bafee3/jwk.go#L155
         # https://github.com/square/go-jose/blob/4ddd71883fa547d37fbf598071f04512d8bafee3/jwk_test.go#L331-L344
         # https://github.com/square/go-jose/blob/4ddd71883fa547d37fbf598071f04512d8bafee3/jwk_test.go#L384
         from josepy.jwk import JWKRSA
-        key = JWKRSA.json_loads("""{
+
+        key = JWKRSA.json_loads(
+            """{
     "kty": "RSA",
     "kid": "bilbo.baggins@hobbiton.example",
     "use": "sig",
     "n": "n4EPtAOCc9AlkeQHPzHStgAbgs7bTZLwUBZdR8_KuKPEHLd4rHVTeT-O-XV2jRojdNhxJWTDvNd7nqQ0VEiZQHz_AJmSCpMaJMRBSFKrKb2wqVwGU_NsYOYL-QtiWN2lbzcEe6XC0dApr5ydQLrHqkHHig3RBordaZ6Aj-oBHqFEHYpPe7Tpe-OfVfHd1E6cS6M1FZcD1NNLYD5lFHpPI9bTwJlsde3uhGqC0ZCuEHg8lhzwOHrtIQbS0FVbb9k3-tVTU4fg_3L_vniUFAKwuCLqKnS2BYwdq_mzSnbLY7h_qixoR7jig3__kRhuaxwUkRz5iaiQkqgc5gHdrNP5zw",
     "e": "AQAB"
-}""")  # noqa
-        assert binascii.hexlify(key.thumbprint()) == \
-            b"f63838e96077ad1fc01c3f8405774dedc0641f558ebb4b40dccf5f9b6d66a932"
+}"""
+        )  # noqa
+        assert (
+            binascii.hexlify(key.thumbprint())
+            == b"f63838e96077ad1fc01c3f8405774dedc0641f558ebb4b40dccf5f9b6d66a932"
+        )
 
 
 class JWKECTest(unittest.TestCase, JWKTestBaseMixin):
     """Tests for josepy.jwk.JWKEC."""
+
     # pylint: disable=too-many-instance-attributes
 
-    thumbprint = (b'\x06\xceL\x1b\xa8\x8d\x86\x1flF\x99J\x8b\xe0$\t\xbbj'
-                  b'\xd8\xf6O\x1ed\xdeR\x8f\x97\xff\xf6\xa2\x86\xd3')
+    thumbprint = (
+        b"\x06\xceL\x1b\xa8\x8d\x86\x1flF\x99J\x8b\xe0$\t\xbbj"
+        b"\xd8\xf6O\x1ed\xdeR\x8f\x97\xff\xf6\xa2\x86\xd3"
+    )
 
     def setUp(self) -> None:
         from josepy.jwk import JWKEC
+
         self.jwk256 = JWKEC(key=EC_P256_KEY.public_key())
         self.jwk384 = JWKEC(key=EC_P384_KEY.public_key())
         self.jwk521 = JWKEC(key=EC_P521_KEY.public_key())
         self.jwk256_not_comparable = JWKEC(key=EC_P256_KEY.public_key()._wrapped)
         self.jwk256json = {
-            'kty': 'EC',
-            'crv': 'P-256',
-            'x': 'jjQtV-fA7J_tK8dPzYq7jRPNjF8r5p6LW2R25S2Gw5U',
-            'y': 'EPAw8_8z7PYKsHH6hlGSlsWxFoFl7-0vM0QRGbmnvCc',
+            "kty": "EC",
+            "crv": "P-256",
+            "x": "jjQtV-fA7J_tK8dPzYq7jRPNjF8r5p6LW2R25S2Gw5U",
+            "y": "EPAw8_8z7PYKsHH6hlGSlsWxFoFl7-0vM0QRGbmnvCc",
         }
         self.jwk384json = {
-            'kty': 'EC',
-            'crv': 'P-384',
-            'x': 'tIhpNtEXkadUbrY84rYGgApFM1X_3l3EWQRuOP1IWtxlTftrZQwneJZF0k0eRn00',
-            'y': 'KW2Gp-TThDXmZ-9MJPnD8hv-X130SVvfZRl1a04HPVwIbvLe87mvA_iuOa-myUyv',
+            "kty": "EC",
+            "crv": "P-384",
+            "x": "tIhpNtEXkadUbrY84rYGgApFM1X_3l3EWQRuOP1IWtxlTftrZQwneJZF0k0eRn00",
+            "y": "KW2Gp-TThDXmZ-9MJPnD8hv-X130SVvfZRl1a04HPVwIbvLe87mvA_iuOa-myUyv",
         }
         self.jwk521json = {
-            'kty': 'EC',
-            'crv': 'P-521',
-            'x': 'AFkdl6cKzBmP18U8fffpP4IZN2eED45hDcwRPl5ZeClwHcLtnMBMuWYFFO_Nzm6DL2MhpN0zI2bcMLJd95aY2tPs',  # noqa
-            'y': 'AYvZq3wByjt7nQd8nYMqhFNCL3j_-U6GPWZet1hYBY_XZHrC4yIV0R4JnssRAY9eqc1EElpCc4hziis1jiV1iR4W',  # noqa
+            "kty": "EC",
+            "crv": "P-521",
+            "x": "AFkdl6cKzBmP18U8fffpP4IZN2eED45hDcwRPl5ZeClwHcLtnMBMuWYFFO_Nzm6DL2MhpN0zI2bcMLJd95aY2tPs",  # noqa
+            "y": "AYvZq3wByjt7nQd8nYMqhFNCL3j_-U6GPWZet1hYBY_XZHrC4yIV0R4JnssRAY9eqc1EElpCc4hziis1jiV1iR4W",  # noqa
         }
         self.private = JWKEC(key=EC_P256_KEY)
         self.private_json = {
-            'd': 'xReNQBKqqTthG8oTmBdhp4EQYImSK1dVqfa2yyMn2rc',
-            'x': 'jjQtV-fA7J_tK8dPzYq7jRPNjF8r5p6LW2R25S2Gw5U',
-            'y': 'EPAw8_8z7PYKsHH6hlGSlsWxFoFl7-0vM0QRGbmnvCc',
-            'crv': 'P-256',
-            'kty': 'EC'}
+            "d": "xReNQBKqqTthG8oTmBdhp4EQYImSK1dVqfa2yyMn2rc",
+            "x": "jjQtV-fA7J_tK8dPzYq7jRPNjF8r5p6LW2R25S2Gw5U",
+            "y": "EPAw8_8z7PYKsHH6hlGSlsWxFoFl7-0vM0QRGbmnvCc",
+            "crv": "P-256",
+            "kty": "EC",
+        }
         self.jwk = self.private
 
     def test_init_auto_comparable(self) -> None:
@@ -248,7 +276,7 @@ class JWKECTest(unittest.TestCase, JWKTestBaseMixin):
 
         # pylint: disable=protected-access
         # TODO: move encode/decode _param to separate class
-        assert 'AA' == JWKEC._encode_param(0, 1)
+        assert "AA" == JWKEC._encode_param(0, 1)
 
     def test_equals(self) -> None:
         assert self.jwk256 == self.jwk256
@@ -265,8 +293,8 @@ class JWKECTest(unittest.TestCase, JWKTestBaseMixin):
 
     def test_load(self) -> None:
         from josepy.jwk import JWKEC
-        assert self.private == JWKEC.load(
-            test_util.load_vector('ec_p256_key.pem'))
+
+        assert self.private == JWKEC.load(test_util.load_vector("ec_p256_key.pem"))
 
     def test_public_key(self) -> None:
         assert self.jwk256 == self.private.public_key()
@@ -279,6 +307,7 @@ class JWKECTest(unittest.TestCase, JWKTestBaseMixin):
 
     def test_from_json(self) -> None:
         from josepy.jwk import JWK
+
         assert self.jwk256 == JWK.from_json(self.jwk256json)
         assert self.jwk384 == JWK.from_json(self.jwk384json)
         assert self.jwk521 == JWK.from_json(self.jwk521json)
@@ -286,45 +315,63 @@ class JWKECTest(unittest.TestCase, JWKTestBaseMixin):
 
     def test_from_json_missing_x_coordinate(self) -> None:
         from josepy.jwk import JWK
-        del self.private_json['x']
+
+        del self.private_json["x"]
         with pytest.raises(KeyError):
             JWK.from_json(self.private_json)
 
     def test_from_json_missing_y_coordinate(self) -> None:
         from josepy.jwk import JWK
-        del self.private_json['y']
+
+        del self.private_json["y"]
         with pytest.raises(KeyError):
             JWK.from_json(self.private_json)
 
     def test_from_json_hashable(self) -> None:
         from josepy.jwk import JWK
+
         hash(JWK.from_json(self.jwk256json))
 
     def test_from_json_non_schema_errors(self) -> None:
         # valid against schema, but still failing
         from josepy.jwk import JWK
+
         with pytest.raises(errors.DeserializationError):
-            JWK.from_json({'kty': 'EC', 'crv': 'P-256', 'x': 'AQAB',
-                           'y': 'm2Fylv-Uz7trgTW8EBHP3FQSMeZs2GNQ6VRo1sIVJEk'})
+            JWK.from_json(
+                {
+                    "kty": "EC",
+                    "crv": "P-256",
+                    "x": "AQAB",
+                    "y": "m2Fylv-Uz7trgTW8EBHP3FQSMeZs2GNQ6VRo1sIVJEk",
+                }
+            )
         with pytest.raises(errors.DeserializationError):
-            JWK.from_json({
-                'kty': 'EC',
-                'crv': 'P-256',
-                'x': 'jjQtV-fA7J_tK8dPzYq7jRPNjF8r5p6LW2R25S2Gw5U',
-                'y': '1',
-            })
+            JWK.from_json(
+                {
+                    "kty": "EC",
+                    "crv": "P-256",
+                    "x": "jjQtV-fA7J_tK8dPzYq7jRPNjF8r5p6LW2R25S2Gw5U",
+                    "y": "1",
+                }
+            )
 
     def test_unknown_crv_name(self) -> None:
         from josepy.jwk import JWK
+
         with pytest.raises(errors.DeserializationError):
-            JWK.from_json({'kty': 'EC',
-                           'crv': 'P-255',
-                           'x': 'jjQtV-fA7J_tK8dPzYq7jRPNjF8r5p6LW2R25S2Gw5U',
-                           'y': 'EPAw8_8z7PYKsHH6hlGSlsWxFoFl7-0vM0QRGbmnvCc'})
+            JWK.from_json(
+                {
+                    "kty": "EC",
+                    "crv": "P-255",
+                    "x": "jjQtV-fA7J_tK8dPzYq7jRPNjF8r5p6LW2R25S2Gw5U",
+                    "y": "EPAw8_8z7PYKsHH6hlGSlsWxFoFl7-0vM0QRGbmnvCc",
+                }
+            )
 
     def test_encode_y_leading_zero_p256(self) -> None:
         import josepy
         from josepy.jwk import JWK, JWKEC
+
         data = b"""-----BEGIN EC PRIVATE KEY-----
 MHcCAQEEICZ7LCI99Na2KZ/Fq8JmJROakGJ5+J7rHiGSPoO36kOAoAoGCCqGSM49
 AwEHoUQDQgAEGS5RvStca15z2FEanCM3juoX7tE/LB7iD44GWawGE40APAl/iZuH
@@ -332,11 +379,11 @@ AwEHoUQDQgAEGS5RvStca15z2FEanCM3juoX7tE/LB7iD44GWawGE40APAl/iZuH
 -----END EC PRIVATE KEY-----"""
         key = JWKEC.load(data)
         json = key.to_partial_json()
-        y = josepy.json_util.decode_b64jose(json['y'])
+        y = josepy.json_util.decode_b64jose(json["y"])
         assert y[0] == 0
         assert len(y) == 32
         JWK.from_json(json)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/tests/jwk_test.py
+++ b/tests/jwk_test.py
@@ -214,8 +214,8 @@ class JWKRSATest(unittest.TestCase, JWKTestBaseMixin):
     "use": "sig",
     "n": "n4EPtAOCc9AlkeQHPzHStgAbgs7bTZLwUBZdR8_KuKPEHLd4rHVTeT-O-XV2jRojdNhxJWTDvNd7nqQ0VEiZQHz_AJmSCpMaJMRBSFKrKb2wqVwGU_NsYOYL-QtiWN2lbzcEe6XC0dApr5ydQLrHqkHHig3RBordaZ6Aj-oBHqFEHYpPe7Tpe-OfVfHd1E6cS6M1FZcD1NNLYD5lFHpPI9bTwJlsde3uhGqC0ZCuEHg8lhzwOHrtIQbS0FVbb9k3-tVTU4fg_3L_vniUFAKwuCLqKnS2BYwdq_mzSnbLY7h_qixoR7jig3__kRhuaxwUkRz5iaiQkqgc5gHdrNP5zw",
     "e": "AQAB"
-}"""
-        )  # noqa
+}"""  # noqa
+        )
         assert (
             binascii.hexlify(key.thumbprint())
             == b"f63838e96077ad1fc01c3f8405774dedc0641f558ebb4b40dccf5f9b6d66a932"

--- a/tests/jws_test.py
+++ b/tests/jws_test.py
@@ -10,8 +10,8 @@ import test_util
 
 from josepy import errors, json_util, jwa, jwk
 
-CERT = test_util.load_comparable_cert('cert.pem')
-KEY = jwk.JWKRSA.load(test_util.load_vector('rsa512_key.pem'))
+CERT = test_util.load_comparable_cert("cert.pem")
+KEY = jwk.JWKRSA.load(test_util.load_vector("rsa512_key.pem"))
 
 
 class MediaTypeTest(unittest.TestCase):
@@ -19,15 +19,17 @@ class MediaTypeTest(unittest.TestCase):
 
     def test_decode(self) -> None:
         from josepy.jws import MediaType
-        assert 'application/app' == MediaType.decode('application/app')
-        assert 'application/app' == MediaType.decode('app')
+
+        assert "application/app" == MediaType.decode("application/app")
+        assert "application/app" == MediaType.decode("app")
         with pytest.raises(errors.DeserializationError):
-            MediaType.decode('app;foo')
+            MediaType.decode("app;foo")
 
     def test_encode(self) -> None:
         from josepy.jws import MediaType
-        assert 'app' == MediaType.encode('application/app')
-        assert 'application/app;foo' == MediaType.encode('application/app;foo')
+
+        assert "app" == MediaType.encode("application/app")
+        assert "application/app;foo" == MediaType.encode("application/app;foo")
 
 
 class HeaderTest(unittest.TestCase):
@@ -35,15 +37,16 @@ class HeaderTest(unittest.TestCase):
 
     def setUp(self) -> None:
         from josepy.jws import Header
-        self.header1 = Header(jwk='foo')
-        self.header2 = Header(jwk='bar')
-        self.crit = Header(crit=('a', 'b'))
+
+        self.header1 = Header(jwk="foo")
+        self.header2 = Header(jwk="bar")
+        self.crit = Header(crit=("a", "b"))
         self.empty = Header()
 
     def test_add_non_empty(self) -> None:
         from josepy.jws import Header
-        assert Header(jwk='foo', crit=('a', 'b')) == \
-            self.header1 + self.crit
+
+        assert Header(jwk="foo", crit=("a", "b")) == self.header1 + self.crit
 
     def test_add_empty(self) -> None:
         assert self.header1 == self.header1 + self.empty
@@ -55,30 +58,31 @@ class HeaderTest(unittest.TestCase):
 
     def test_add_wrong_type_error(self) -> None:
         with pytest.raises(TypeError):
-            self.header1.__add__('xxx')
+            self.header1.__add__("xxx")
 
     def test_crit_decode_always_errors(self) -> None:
         from josepy.jws import Header
+
         with pytest.raises(errors.DeserializationError):
-            Header.from_json({'crit': ['a', 'b']})
+            Header.from_json({"crit": ["a", "b"]})
 
     def test_x5c_decoding(self) -> None:
         from josepy.jws import Header
+
         header = Header(x5c=(CERT, CERT))
         jobj = header.to_partial_json()
         assert isinstance(CERT.wrapped, OpenSSL.crypto.X509)
-        cert_asn1 = OpenSSL.crypto.dump_certificate(
-            OpenSSL.crypto.FILETYPE_ASN1, CERT.wrapped)
+        cert_asn1 = OpenSSL.crypto.dump_certificate(OpenSSL.crypto.FILETYPE_ASN1, CERT.wrapped)
         cert_b64 = base64.b64encode(cert_asn1)
-        assert jobj == {'x5c': [cert_b64, cert_b64]}
+        assert jobj == {"x5c": [cert_b64, cert_b64]}
         assert header == Header.from_json(jobj)
-        jobj['x5c'][0] = base64.b64encode(b'xxx' + cert_asn1)
+        jobj["x5c"][0] = base64.b64encode(b"xxx" + cert_asn1)
         with pytest.raises(errors.DeserializationError):
             Header.from_json(jobj)
 
     def test_find_key(self) -> None:
-        assert 'foo' == self.header1.find_key()
-        assert 'bar' == self.header2.find_key()
+        assert "foo" == self.header1.find_key()
+        assert "bar" == self.header2.find_key()
         with pytest.raises(errors.Error):
             self.crit.find_key()
 
@@ -88,14 +92,16 @@ class SignatureTest(unittest.TestCase):
 
     def test_from_json(self) -> None:
         from josepy.jws import Header, Signature
-        assert Signature(signature=b'foo', header=Header(alg=jwa.RS256)) == \
-            Signature.from_json(
-                {'signature': 'Zm9v', 'header': {'alg': 'RS256'}})
+
+        assert Signature(signature=b"foo", header=Header(alg=jwa.RS256)) == Signature.from_json(
+            {"signature": "Zm9v", "header": {"alg": "RS256"}}
+        )
 
     def test_from_json_no_alg_error(self) -> None:
         from josepy.jws import Signature
+
         with pytest.raises(errors.DeserializationError):
-            Signature.from_json({'signature': 'foo'})
+            Signature.from_json({"signature": "foo"})
 
 
 class JWSTest(unittest.TestCase):
@@ -106,14 +112,14 @@ class JWSTest(unittest.TestCase):
         self.pubkey = self.privkey.public_key()
 
         from josepy.jws import JWS
-        self.unprotected = JWS.sign(
-            payload=b'foo', key=self.privkey, alg=jwa.RS256)
+
+        self.unprotected = JWS.sign(payload=b"foo", key=self.privkey, alg=jwa.RS256)
         self.protected = JWS.sign(
-            payload=b'foo', key=self.privkey, alg=jwa.RS256,
-            protect=frozenset(['jwk', 'alg']))
+            payload=b"foo", key=self.privkey, alg=jwa.RS256, protect=frozenset(["jwk", "alg"])
+        )
         self.mixed = JWS.sign(
-            payload=b'foo', key=self.privkey, alg=jwa.RS256,
-            protect=frozenset(['alg']))
+            payload=b"foo", key=self.privkey, alg=jwa.RS256, protect=frozenset(["alg"])
+        )
 
     def test_pubkey_jwk(self) -> None:
         assert self.unprotected.signature.combined.jwk == self.pubkey
@@ -131,114 +137,119 @@ class JWSTest(unittest.TestCase):
 
     def test_compact_lost_unprotected(self) -> None:
         compact = self.mixed.to_compact()
-        assert b'eyJhbGciOiAiUlMyNTYifQ.Zm9v.OHdxFVj73l5LpxbFp1AmYX4yJM0Pyb' \
-            b'_893n1zQjpim_eLS5J1F61lkvrCrCDErTEJnBGOGesJ72M7b6Ve1cAJA' == \
-            compact
+        assert (
+            b"eyJhbGciOiAiUlMyNTYifQ.Zm9v.OHdxFVj73l5LpxbFp1AmYX4yJM0Pyb"
+            b"_893n1zQjpim_eLS5J1F61lkvrCrCDErTEJnBGOGesJ72M7b6Ve1cAJA" == compact
+        )
 
         from josepy.jws import JWS
+
         mixed = JWS.from_compact(compact)
 
         assert self.mixed != mixed
-        assert {'alg'} == set(mixed.signature.combined.not_omitted())
+        assert {"alg"} == set(mixed.signature.combined.not_omitted())
 
     def test_from_compact_missing_components(self) -> None:
         from josepy.jws import JWS
+
         with pytest.raises(errors.DeserializationError):
-            JWS.from_compact(b'.')
+            JWS.from_compact(b".")
 
     def test_json_omitempty(self) -> None:
         protected_jobj = self.protected.to_partial_json(flat=True)
         unprotected_jobj = self.unprotected.to_partial_json(flat=True)
 
-        assert 'protected' not in unprotected_jobj
-        assert 'header' not in protected_jobj
+        assert "protected" not in unprotected_jobj
+        assert "header" not in protected_jobj
 
-        unprotected_jobj['header'] = unprotected_jobj['header'].to_json()
+        unprotected_jobj["header"] = unprotected_jobj["header"].to_json()
 
         from josepy.jws import JWS
+
         assert JWS.from_json(protected_jobj) == self.protected
         assert JWS.from_json(unprotected_jobj) == self.unprotected
 
     def test_json_flat(self) -> None:
         jobj_to = {
-            'signature': json_util.encode_b64jose(
-                self.mixed.signature.signature),
-            'payload': json_util.encode_b64jose(b'foo'),
-            'header': self.mixed.signature.header,
-            'protected': json_util.encode_b64jose(
-                self.mixed.signature.protected.encode('utf-8')),
+            "signature": json_util.encode_b64jose(self.mixed.signature.signature),
+            "payload": json_util.encode_b64jose(b"foo"),
+            "header": self.mixed.signature.header,
+            "protected": json_util.encode_b64jose(self.mixed.signature.protected.encode("utf-8")),
         }
 
         from josepy.jws import Header
+
         jobj_from = jobj_to.copy()
-        header = jobj_from['header']
+        header = jobj_from["header"]
         assert isinstance(header, Header)
-        jobj_from['header'] = header.to_json()
+        jobj_from["header"] = header.to_json()
 
         assert self.mixed.to_partial_json(flat=True) == jobj_to
         from josepy.jws import JWS
+
         assert self.mixed == JWS.from_json(jobj_from)
 
     def test_json_not_flat(self) -> None:
         jobj_to = {
-            'signatures': (self.mixed.signature,),
-            'payload': json_util.encode_b64jose(b'foo'),
+            "signatures": (self.mixed.signature,),
+            "payload": json_util.encode_b64jose(b"foo"),
         }
         jobj_from = jobj_to.copy()
-        signature = jobj_to['signatures'][0]
+        signature = jobj_to["signatures"][0]
         from josepy.jws import Signature
+
         assert isinstance(signature, Signature)
-        jobj_from['signatures'] = [signature.to_json()]
+        jobj_from["signatures"] = [signature.to_json()]
 
         assert self.mixed.to_partial_json(flat=False) == jobj_to
         from josepy.jws import JWS
+
         assert self.mixed == JWS.from_json(jobj_from)
 
     def test_from_json_mixed_flat(self) -> None:
         from josepy.jws import JWS
+
         with pytest.raises(errors.DeserializationError):
-            JWS.from_json({'signatures': (), 'signature': 'foo'})
+            JWS.from_json({"signatures": (), "signature": "foo"})
 
     def test_from_json_hashable(self) -> None:
         from josepy.jws import JWS
+
         hash(JWS.from_json(self.mixed.to_json()))
 
 
 class CLITest(unittest.TestCase):
-
     def setUp(self) -> None:
-        self.key_path = test_util.vector_path('rsa512_key.pem')
+        self.key_path = test_util.vector_path("rsa512_key.pem")
 
     def test_unverified(self) -> None:
         from josepy.jws import CLI
-        with mock.patch('sys.stdin') as sin:
+
+        with mock.patch("sys.stdin") as sin:
             sin.read.return_value = '{"payload": "foo", "signature": "xxx"}'
-            with mock.patch('sys.stdout'):
-                assert CLI.run(['verify']) is False
+            with mock.patch("sys.stdout"):
+                assert CLI.run(["verify"]) is False
 
     def test_json(self) -> None:
         from josepy.jws import CLI
 
-        with mock.patch('sys.stdin') as sin:
-            sin.read.return_value = 'foo'
-            with mock.patch('sys.stdout') as sout:
-                CLI.run(['sign', '-k', self.key_path, '-a', 'RS256',
-                         '-p', 'jwk'])
+        with mock.patch("sys.stdin") as sin:
+            sin.read.return_value = "foo"
+            with mock.patch("sys.stdout") as sout:
+                CLI.run(["sign", "-k", self.key_path, "-a", "RS256", "-p", "jwk"])
                 sin.read.return_value = sout.write.mock_calls[0][1][0]
-                assert 0 == CLI.run(['verify'])
+                assert 0 == CLI.run(["verify"])
 
     def test_compact(self) -> None:
         from josepy.jws import CLI
 
-        with mock.patch('sys.stdin') as sin:
-            sin.read.return_value = 'foo'
-            with mock.patch('sys.stdout') as sout:
-                CLI.run(['--compact', 'sign', '-k', self.key_path])
+        with mock.patch("sys.stdin") as sin:
+            sin.read.return_value = "foo"
+            with mock.patch("sys.stdout") as sout:
+                CLI.run(["--compact", "sign", "-k", self.key_path])
                 sin.read.return_value = sout.write.mock_calls[0][1][0]
-                assert 0 == CLI.run([
-                    '--compact', 'verify', '--kty', 'RSA',
-                    '-k', self.key_path])
+                assert 0 == CLI.run(["--compact", "verify", "--kty", "RSA", "-k", self.key_path])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/tests/magic_typing_test.py
+++ b/tests/magic_typing_test.py
@@ -8,19 +8,20 @@ import pytest
 
 def test_import_success() -> None:
     import typing as temp_typing
+
     typing_class_mock = mock.MagicMock()
     text_mock = mock.MagicMock()
     typing_class_mock.Text = text_mock
-    sys.modules['typing'] = typing_class_mock
-    if 'josepy.magic_typing' in sys.modules:
-        del sys.modules['josepy.magic_typing']  # pragma: no cover
+    sys.modules["typing"] = typing_class_mock
+    if "josepy.magic_typing" in sys.modules:
+        del sys.modules["josepy.magic_typing"]  # pragma: no cover
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=DeprecationWarning)
         from josepy.magic_typing import Text
     assert Text == text_mock
-    del sys.modules['josepy.magic_typing']
-    sys.modules['typing'] = temp_typing
+    del sys.modules["josepy.magic_typing"]
+    sys.modules["typing"] = temp_typing
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -20,7 +20,7 @@ if sys.version_info >= (3, 9):
 else:
     import importlib_resources
 
-TESTDATA = importlib_resources.files('testdata')
+TESTDATA = importlib_resources.files("testdata")
 
 
 def vector_path(*names: str) -> str:
@@ -42,9 +42,9 @@ def load_vector(*names: str) -> bytes:
 
 def _guess_loader(filename: str, loader_pem: Any, loader_der: Any) -> Any:
     _, ext = os.path.splitext(filename)
-    if ext.lower() == '.pem':
+    if ext.lower() == ".pem":
         return loader_pem
-    elif ext.lower() == '.der':
+    elif ext.lower() == ".der":
         return loader_der
     else:  # pragma: no cover
         raise ValueError("Loader could not be recognized based on extension")
@@ -52,8 +52,7 @@ def _guess_loader(filename: str, loader_pem: Any, loader_der: Any) -> Any:
 
 def load_cert(*names: str) -> crypto.X509:
     """Load certificate."""
-    loader = _guess_loader(
-        names[-1], crypto.FILETYPE_PEM, crypto.FILETYPE_ASN1)
+    loader = _guess_loader(names[-1], crypto.FILETYPE_PEM, crypto.FILETYPE_ASN1)
     return crypto.load_certificate(loader, load_vector(*names))
 
 
@@ -64,8 +63,7 @@ def load_comparable_cert(*names: str) -> josepy.util.ComparableX509:
 
 def load_csr(*names: str) -> crypto.X509Req:
     """Load certificate request."""
-    loader = _guess_loader(
-        names[-1], crypto.FILETYPE_PEM, crypto.FILETYPE_ASN1)
+    loader = _guess_loader(names[-1], crypto.FILETYPE_PEM, crypto.FILETYPE_ASN1)
     return crypto.load_certificate_request(loader, load_vector(*names))
 
 
@@ -76,22 +74,21 @@ def load_comparable_csr(*names: str) -> josepy.util.ComparableX509:
 
 def load_rsa_private_key(*names: str) -> josepy.util.ComparableRSAKey:
     """Load RSA private key."""
-    loader = _guess_loader(names[-1], serialization.load_pem_private_key,
-                           serialization.load_der_private_key)
-    return ComparableRSAKey(loader(
-        load_vector(*names), password=None, backend=default_backend()))
+    loader = _guess_loader(
+        names[-1], serialization.load_pem_private_key, serialization.load_der_private_key
+    )
+    return ComparableRSAKey(loader(load_vector(*names), password=None, backend=default_backend()))
 
 
 def load_ec_private_key(*names: str) -> josepy.util.ComparableECKey:
     """Load EC private key."""
-    loader = _guess_loader(names[-1], serialization.load_pem_private_key,
-                           serialization.load_der_private_key)
-    return ComparableECKey(loader(
-        load_vector(*names), password=None, backend=default_backend()))
+    loader = _guess_loader(
+        names[-1], serialization.load_pem_private_key, serialization.load_der_private_key
+    )
+    return ComparableECKey(loader(load_vector(*names), password=None, backend=default_backend()))
 
 
 def load_pyopenssl_private_key(*names: str) -> crypto.PKey:
     """Load pyOpenSSL private key."""
-    loader = _guess_loader(
-        names[-1], crypto.FILETYPE_PEM, crypto.FILETYPE_ASN1)
+    loader = _guess_loader(names[-1], crypto.FILETYPE_PEM, crypto.FILETYPE_ASN1)
     return crypto.load_privatekey(loader, load_vector(*names))

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -12,13 +12,13 @@ class ComparableX509Test(unittest.TestCase):
 
     def setUp(self) -> None:
         # test_util.load_comparable_{csr,cert} return ComparableX509
-        self.req1 = test_util.load_comparable_csr('csr.pem')
-        self.req2 = test_util.load_comparable_csr('csr.pem')
-        self.req_other = test_util.load_comparable_csr('csr-san.pem')
+        self.req1 = test_util.load_comparable_csr("csr.pem")
+        self.req2 = test_util.load_comparable_csr("csr.pem")
+        self.req_other = test_util.load_comparable_csr("csr-san.pem")
 
-        self.cert1 = test_util.load_comparable_cert('cert.pem')
-        self.cert2 = test_util.load_comparable_cert('cert.pem')
-        self.cert_other = test_util.load_comparable_cert('cert-san.pem')
+        self.cert1 = test_util.load_comparable_cert("cert.pem")
+        self.cert2 = test_util.load_comparable_cert("cert.pem")
+        self.cert_other = test_util.load_comparable_cert("cert-san.pem")
 
     def test_getattr_proxy(self) -> None:
         assert self.cert1.has_expired() is True
@@ -44,8 +44,7 @@ class ComparableX509Test(unittest.TestCase):
 
     def test_repr(self) -> None:
         for x509 in self.req1, self.cert1:
-            assert repr(x509) == \
-                '<ComparableX509({0!r})>'.format(x509.wrapped)
+            assert repr(x509) == "<ComparableX509({0!r})>".format(x509.wrapped)
 
 
 class ComparableRSAKeyTest(unittest.TestCase):
@@ -53,9 +52,9 @@ class ComparableRSAKeyTest(unittest.TestCase):
 
     def setUp(self) -> None:
         # test_utl.load_rsa_private_key return ComparableRSAKey
-        self.key = test_util.load_rsa_private_key('rsa256_key.pem')
-        self.key_same = test_util.load_rsa_private_key('rsa256_key.pem')
-        self.key2 = test_util.load_rsa_private_key('rsa512_key.pem')
+        self.key = test_util.load_rsa_private_key("rsa256_key.pem")
+        self.key_same = test_util.load_rsa_private_key("rsa256_key.pem")
+        self.key2 = test_util.load_rsa_private_key("rsa512_key.pem")
 
     def test_getattr_proxy(self) -> None:
         assert 256 == self.key.key_size
@@ -74,6 +73,7 @@ class ComparableRSAKeyTest(unittest.TestCase):
 
     def test_ne_no_serialization(self) -> None:
         from josepy.util import ComparableRSAKey
+
         assert ComparableRSAKey(5) != ComparableRSAKey(5)  # type: ignore
 
     def test_hash(self) -> None:
@@ -82,11 +82,11 @@ class ComparableRSAKeyTest(unittest.TestCase):
         assert hash(self.key) != hash(self.key2)
 
     def test_repr(self) -> None:
-        assert repr(self.key).startswith(
-            '<ComparableRSAKey(<cryptography.hazmat.') is True
+        assert repr(self.key).startswith("<ComparableRSAKey(<cryptography.hazmat.") is True
 
     def test_public_key(self) -> None:
         from josepy.util import ComparableRSAKey
+
         assert isinstance(self.key.public_key(), ComparableRSAKey)
 
 
@@ -95,10 +95,10 @@ class ComparableECKeyTest(unittest.TestCase):
 
     def setUp(self) -> None:
         # test_utl.load_ec_private_key return ComparableECKey
-        self.p256_key = test_util.load_ec_private_key('ec_p256_key.pem')
-        self.p256_key_same = test_util.load_ec_private_key('ec_p256_key.pem')
-        self.p384_key = test_util.load_ec_private_key('ec_p384_key.pem')
-        self.p521_key = test_util.load_ec_private_key('ec_p521_key.pem')
+        self.p256_key = test_util.load_ec_private_key("ec_p256_key.pem")
+        self.p256_key_same = test_util.load_ec_private_key("ec_p256_key.pem")
+        self.p384_key = test_util.load_ec_private_key("ec_p384_key.pem")
+        self.p521_key = test_util.load_ec_private_key("ec_p521_key.pem")
 
     def test_getattr_proxy(self) -> None:
         assert 256 == self.p256_key.key_size
@@ -118,6 +118,7 @@ class ComparableECKeyTest(unittest.TestCase):
 
     def test_ne_no_serialization(self) -> None:
         from josepy.util import ComparableECKey
+
         assert ComparableECKey(5) != ComparableECKey(5)  # type: ignore
 
     def test_hash(self) -> None:
@@ -127,11 +128,11 @@ class ComparableECKeyTest(unittest.TestCase):
         assert hash(self.p256_key) != hash(self.p521_key)
 
     def test_repr(self) -> None:
-        assert repr(self.p256_key).startswith(
-            '<ComparableECKey(<cryptography.hazmat.') is True
+        assert repr(self.p256_key).startswith("<ComparableECKey(<cryptography.hazmat.") is True
 
     def test_public_key(self) -> None:
         from josepy.util import ComparableECKey
+
         assert isinstance(self.p256_key.public_key(), ComparableECKey)
 
 
@@ -144,12 +145,12 @@ class ImmutableMapTest(unittest.TestCase):
         class A(ImmutableMap):
             x: int
             y: int
-            __slots__ = ('x', 'y')
+            __slots__ = ("x", "y")
 
         class B(ImmutableMap):
             x: int
             y: int
-            __slots__ = ('x', 'y')
+            __slots__ = ("x", "y")
 
         self.A = A
         self.B = B
@@ -165,7 +166,7 @@ class ImmutableMapTest(unittest.TestCase):
 
     def test_get_missing_item_raises_key_error(self) -> None:
         with pytest.raises(KeyError):
-            self.a1.__getitem__('z')
+            self.a1.__getitem__("z")
 
     def test_order_of_args_does_not_matter(self) -> None:
         assert self.a1 == self.a1_swap
@@ -190,7 +191,7 @@ class ImmutableMapTest(unittest.TestCase):
 
     def test_set_attr_raises_attribute_error(self) -> None:
         with pytest.raises(AttributeError):
-            functools.partial(self.a1.__setattr__, 'x')(10)
+            functools.partial(self.a1.__setattr__, "x")(10)
 
     def test_equal(self) -> None:
         assert self.a1 == self.a1
@@ -205,10 +206,10 @@ class ImmutableMapTest(unittest.TestCase):
             self.A(x=1, y={}).__hash__()
 
     def test_repr(self) -> None:
-        assert 'A(x=1, y=2)' == repr(self.a1)
-        assert 'A(x=1, y=2)' == repr(self.a1_swap)
-        assert 'B(x=1, y=2)' == repr(self.b)
-        assert "B(x='foo', y='bar')" == repr(self.B(x='foo', y='bar'))
+        assert "A(x=1, y=2)" == repr(self.a1)
+        assert "A(x=1, y=2)" == repr(self.a1_swap)
+        assert "B(x=1, y=2)" == repr(self.b)
+        assert "B(x='foo', y='bar')" == repr(self.B(x="foo", y="bar"))
 
 
 class frozendictTest(unittest.TestCase):
@@ -216,18 +217,20 @@ class frozendictTest(unittest.TestCase):
 
     def setUp(self) -> None:
         from josepy.util import frozendict
-        self.fdict = frozendict(x=1, y='2')
+
+        self.fdict = frozendict(x=1, y="2")
 
     def test_init_dict(self) -> None:
         from josepy.util import frozendict
-        assert self.fdict == frozendict({'x': 1, 'y': '2'})
+
+        assert self.fdict == frozendict({"x": 1, "y": "2"})
 
     def test_init_other_raises_type_error(self) -> None:
         from josepy.util import frozendict
 
         # specifically fail for generators...
         with pytest.raises(TypeError):
-            frozendict({'a': 'b'}.items())
+            frozendict({"a": "b"}.items())
 
     def test_len(self) -> None:
         assert 2 == len(self.fdict)
@@ -237,19 +240,19 @@ class frozendictTest(unittest.TestCase):
 
     def test_getattr_proxy(self) -> None:
         assert 1 == self.fdict.x
-        assert '2' == self.fdict.y
+        assert "2" == self.fdict.y
 
     def test_getattr_raises_attribute_error(self) -> None:
         with pytest.raises(AttributeError):
-            self.fdict.__getattr__('z')
+            self.fdict.__getattr__("z")
 
     def test_setattr_immutable(self) -> None:
         with pytest.raises(AttributeError):
-            self.fdict.__setattr__('z', 3)
+            self.fdict.__setattr__("z", 3)
 
     def test_repr(self) -> None:
         assert "frozendict(x=1, y='2')" == repr(self.fdict)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,17 @@
 [tox]
 isolated_build = true
-envlist = py,flake8,isort,mypy
+envlist = py,black,flake8,isort,mypy
 
 [testenv]
 allowlist_externals = poetry
 commands =
     poetry install -v
     poetry run pytest -v --cov-report xml --cov-report=term-missing --cov=josepy {posargs}
+
+[testenv:black]
+commands =
+    poetry install -v
+    poetry run black --check --diff src tests
 
 [testenv:flake8]
 commands =


### PR DESCRIPTION
This PR sets up [black](https://github.com/psf/black), the "uncompromising code formatter", which is maintained on GitHub under the Python Software Foundation, has become very popular, and [is used by many projects](https://github.com/psf/black#used-by) including pyca's cryptography which I feel I often point to as an example of a well maintained project. Using a code formatter like this gives our code a consistent style and automatically fixes many problems our linter would otherwise yell about and make us fix manually.

The first commit here was entirely programmatically generated. To create it, first I installed black with `pip` into the virtual environment and then I ran the command put in the commit message.

The second commit was made manually. I added the first commit to `.git-blame-ignore-revs` to avoid masking `git blame` for simple things like `black` changing the quote style. Doing this is [suggested by black](https://black.readthedocs.io/en/stable/guides/introducing_black_to_your_project.html) and Alex at https://github.com/certbot/certbot/issues/8818. It's worth noting that GitHub does now support this though as described at https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view. Because of the changes to `.git-blame-ignore-revs`, **this PR should not be squashed when it is merged to preserve the commit hash.**

The second commit also included me rewriting some ignore comments for other linters that `black` didn't understand, but this otherwise was pretty easy and straightforward for me to do.