### PR TITLE
Remove setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,0 @@
-[flake8]
-exclude = .git,.tox
-# E203 and W503 are ignored here for compatibility with black
-ignore = E203,W503,W504
-max-line-length = 100

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,9 @@
+[flake8]
+exclude = .git,.tox
+# E203 and W503 are ignored here for compatibility with black
+ignore = E203,W503,W504
+max-line-length = 100
+
 [tox]
 isolated_build = true
 envlist = py,black,flake8,isort,mypy


### PR DESCRIPTION
We don't need this file and can configure flake8 in tox.ini. See https://flake8.pycqa.org/en/latest/user/configuration.html#configuration-locations.