### PR TITLE
Deprecate Python 3.7

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Changelog
 ---------------
 
 * Added support for Python 3.11.
+* Support for Python 3.7 has been deprecated and will be removed in the next
+  scheduled release.
 * Dropped support for Python 3.6.
 * Added a new valid PGP key for signing our PyPI packages with the fingerprint
   F2871B4152AE13C49519111F447BF683AA3B26C3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Topic :: Internet :: WWW/HTTP", 
+    "Topic :: Internet :: WWW/HTTP",
     "Topic :: Security",
 ]
 homepage = "https://github.com/certbot/josepy"
@@ -94,7 +94,8 @@ disallow_untyped_defs = true
 # Pytest tooling configuration
 
 [tool.pytest.ini_options]
-filterwarnings = ["error"]
+# We also ignore our own deprecation warning about dropping Python 3.7 support.
+filterwarnings = ["error", "ignore:Python 3.7 support will be dropped:DeprecationWarning"]
 norecursedirs = "*.egg .eggs dist build docs .tox"
 
 # Isort tooling configuration

--- a/src/josepy/__init__.py
+++ b/src/josepy/__init__.py
@@ -25,6 +25,9 @@ Originally developed as part of the ACME_ protocol implementation.
 .. _ACME: https://pypi.python.org/pypi/acme
 
 """
+import sys
+import warnings
+
 # flake8: noqa
 from josepy.b64 import b64decode, b64encode
 from josepy.errors import (
@@ -72,3 +75,10 @@ from josepy.util import (
     ComparableX509,
     ImmutableMap,
 )
+
+if sys.version_info[:2] == (3, 7):
+    warnings.warn(
+        "Python 3.7 support will be dropped in the next scheduled release of "
+        "josepy. Please upgrade your Python version.",
+        DeprecationWarning,
+    )

--- a/tests/init_test.py
+++ b/tests/init_test.py
@@ -1,0 +1,25 @@
+import importlib
+import re
+import sys
+import warnings
+
+import pytest
+
+import josepy
+
+
+@pytest.mark.skipif(sys.version_info[:2] != (3, 7), reason="requires Python 3.7")
+def test_warns():
+    with pytest.warns(DeprecationWarning, match=re.escape(r"Python 3.7 support")):
+        importlib.reload(josepy)
+
+
+@pytest.mark.skipif(sys.version_info[:2] == (3, 7), reason="requires Python != 3.7")
+def test_does_not_warn():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        importlib.reload(josepy)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(sys.argv[1:] + [__file__]))  # pragma: no cover

--- a/tests/init_test.py
+++ b/tests/init_test.py
@@ -9,13 +9,13 @@ import josepy
 
 
 @pytest.mark.skipif(sys.version_info[:2] != (3, 7), reason="requires Python 3.7")
-def test_warns():
+def test_warns() -> None:
     with pytest.warns(DeprecationWarning, match=re.escape(r"Python 3.7 support")):
         importlib.reload(josepy)
 
 
 @pytest.mark.skipif(sys.version_info[:2] == (3, 7), reason="requires Python != 3.7")
-def test_does_not_warn():
+def test_does_not_warn() -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         importlib.reload(josepy)


### PR DESCRIPTION
Based on https://github.com/certbot/josepy/pull/132.

Tests may be overkill, but adding some quick tests didn't seem like a bad idea to me.