### PR TITLE
Fix incorrect `include` declarations with Poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,10 @@ homepage = "https://github.com/certbot/josepy"
 authors = ["Certbot Project <certbot-dev@eff.org>"]
 readme = "README.rst"
 include = [
-    "CHANGELOG.rst",
-    "CONTRIBUTING.md",
-    "docs", "tests",
+    {path = "CHANGELOG.rst", format = "sdist"},
+    {path = "CONTRIBUTING.md", format = "sdist"},
+    {path = "docs", format = "sdist"},
+    {path = "tests", format = "sdist"},
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Fix the `include` declarations in `pyproject.toml` to be restricted to the `sdist` format.  Otherwise, all the listed files are installed straight into site-packages, i.e. you get:

    /usr/lib/python3.10/site-packages/CONTRIBUTING.md
    /usr/lib/python3.10/site-packages/CHANGELOG.rst
    ...