### PR TITLE
simplify & standardize poetry usage with readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,8 +12,7 @@ build:
       # https://python-poetry.org/docs/#installing-manually
       - pip install poetry
     post_install:
-      # Install dependencies with 'docs' dependency group
-      # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
+      # Install dependencies with 'docs' extras
       # VIRTUAL_ENV needs to be set manually for now.
       # See https://github.com/readthedocs/readthedocs.org/pull/11152/
       - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --extras docs

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,4 +16,4 @@ build:
       # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
       # VIRTUAL_ENV needs to be set manually for now.
       # See https://github.com/readthedocs/readthedocs.org/pull/11152/
-      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with docs
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --extras docs

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,10 +5,15 @@ build:
   tools:
     python: "3.10"
   jobs:
-    pre_install:
-      - curl -sSL https://install.python-poetry.org | python3 -
-      - ${HOME}/.local/bin/poetry export -f constraints.txt --with dev -E docs --without-hashes > constraints.txt
-
-python:
-  install:
-    - requirements: docs/requirements.txt
+    # this approach was taken from
+    # https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-poetry
+    post_create_environment:
+      # Install poetry
+      # https://python-poetry.org/docs/#installing-manually
+      - pip install poetry
+    post_install:
+      # Install dependencies with 'docs' dependency group
+      # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
+      # VIRTUAL_ENV needs to be set manually for now.
+      # See https://github.com/readthedocs/readthedocs.org/pull/11152/
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with docs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,0 @@
-# We pin our dependencies with a constraints file for increased stability.
-
--c ../constraints.txt
--e .[docs]


### PR DESCRIPTION
i want this to try to help get automated dependabot PRs working to ideally automate some of that work for us. currently, the inclusion of this `requirements.txt` file that references a `constraints.txt` file that is generated on the fly as needed on top of our conventional poetry setup confuses the hell out of dependabot. i've been able to get things working after the changes here on my fork

this PR [seems to work on readthedocs](https://readthedocs.org/projects/josepy/builds/24593984/)