### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -12,8 +12,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      TOXENV: mypy
     strategy:
       fail-fast: false
       matrix:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 24.8.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+    rev: 7.1.1
     hooks:
       - id: flake8
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.5
+    rev: 5.13.2
     hooks:
       - id: isort

--- a/src/josepy/b64.py
+++ b/src/josepy/b64.py
@@ -10,6 +10,7 @@
    standard library.
 
 """
+
 import base64
 from typing import Union
 

--- a/src/josepy/errors.py
+++ b/src/josepy/errors.py
@@ -1,4 +1,5 @@
 """JOSE errors."""
+
 from typing import Any
 
 

--- a/src/josepy/interfaces.py
+++ b/src/josepy/interfaces.py
@@ -1,4 +1,5 @@
 """JOSE interfaces."""
+
 import abc
 import json
 from collections.abc import Mapping, Sequence

--- a/src/josepy/json_util.py
+++ b/src/josepy/json_util.py
@@ -6,6 +6,7 @@ The framework presented here is somewhat based on `Go's "json" package`_
 .. _`Go's "json" package`: http://golang.org/pkg/encoding/json/
 
 """
+
 import abc
 import binascii
 import logging

--- a/src/josepy/jwa.py
+++ b/src/josepy/jwa.py
@@ -3,6 +3,7 @@
 https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40
 
 """
+
 import abc
 import logging
 from collections.abc import Hashable

--- a/src/josepy/jwk.py
+++ b/src/josepy/jwk.py
@@ -1,4 +1,5 @@
 """JSON Web Key."""
+
 import abc
 import json
 import logging

--- a/src/josepy/jws.py
+++ b/src/josepy/jws.py
@@ -1,4 +1,5 @@
 """JSON Web Signature."""
+
 import argparse
 import base64
 import sys

--- a/src/josepy/magic_typing.py
+++ b/src/josepy/magic_typing.py
@@ -1,4 +1,5 @@
 """Shim class to not have to depend on typing module in prod."""
+
 # mypy: ignore-errors
 import sys
 import warnings

--- a/src/josepy/util.py
+++ b/src/josepy/util.py
@@ -1,4 +1,5 @@
 """JOSE utilities."""
+
 import abc
 import sys
 import warnings

--- a/tests/b64_test.py
+++ b/tests/b64_test.py
@@ -1,4 +1,5 @@
 """Tests for josepy.b64."""
+
 import sys
 from typing import Union
 

--- a/tests/errors_test.py
+++ b/tests/errors_test.py
@@ -1,4 +1,5 @@
 """Tests for josepy.errors."""
+
 import sys
 import unittest
 

--- a/tests/interfaces_test.py
+++ b/tests/interfaces_test.py
@@ -1,4 +1,5 @@
 """Tests for josepy.interfaces."""
+
 import sys
 import unittest
 from typing import Any, Dict, List

--- a/tests/json_util_test.py
+++ b/tests/json_util_test.py
@@ -1,4 +1,5 @@
 """Tests for josepy.json_util."""
+
 import itertools
 import sys
 import unittest

--- a/tests/jwa_test.py
+++ b/tests/jwa_test.py
@@ -1,4 +1,5 @@
 """Tests for josepy.jwa."""
+
 import sys
 import unittest
 from typing import Any

--- a/tests/jwk_test.py
+++ b/tests/jwk_test.py
@@ -1,4 +1,5 @@
 """Tests for josepy.jwk."""
+
 import binascii
 import sys
 import unittest

--- a/tests/jws_test.py
+++ b/tests/jws_test.py
@@ -1,4 +1,5 @@
 """Tests for josepy.jws."""
+
 import base64
 import sys
 import unittest

--- a/tests/magic_typing_test.py
+++ b/tests/magic_typing_test.py
@@ -1,4 +1,5 @@
 """Tests for josepy.magic_typing."""
+
 import sys
 import warnings
 from unittest import mock

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,4 +1,5 @@
 """Test utilities."""
+
 import atexit
 import contextlib
 import os

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,4 +1,5 @@
 """Tests for josepy.util."""
+
 import functools
 import sys
 import unittest


### PR DESCRIPTION
I accidentally broke CI in https://github.com/certbot/josepy/pull/160. In that PR I tried to simplify our CI setup by just running `tox` which normally runs all standard tests, but I missed that `TOXENV` was set at the top of the file causing `tox` with no other arguments to only run `mypy`!

This PR fixes that, updates `.pre-commit-config.yaml` so it works with modern Pythons, and applies the minor changes from `black`.