### PR TITLE
ci: don't persist creds in check.yaml

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -18,6 +18,8 @@ jobs:
         python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -40,6 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Setup Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
Hi josepy maintainers! Thanks for your hard work here and on `certbot`; I'm a happy user of both :slightly_smiling_face: 

This fixes two small findings from [`zizmor`](https://github.com/woodruffw/zizmor) for unnecessary credential persistence. These don't appear to be exploitable in this case, but eliminating unnecessary credentials is a good defense-in-depth practice.

See: https://woodruffw.github.io/zizmor/audits/#artipacked for more details.

Repro:

```bash
# 035ea359a2f53611cec079cac98401ec30053a42 is the current master HEAD
zizmor certbot/josepy@035ea359a2f53611cec079cac98401ec30053a42 --gh-token $(gh auth token)
```