### PR TITLE
Switch intersphinx_mapping to new format

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -185,6 +185,6 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "https://docs.python.org/": None,
-    "https://cryptography.io/en/latest/": None,
+    "python": ("https://docs.python.org/", None),
+    "cryptography": ("https://cryptography.io/en/latest/", None),
 }


### PR DESCRIPTION
Sphinx v8 no longer supports intersphinx_mapping being a direct map; it now must be a map with identifiers and tuples.  This fixes a FTBFS downstream in Debian, bug #1090148.