### PR TITLE
Filter warning caused by deprecated pyopenssl usage of datetime

### DIFF
--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -3,6 +3,7 @@
 import functools
 import sys
 import unittest
+import warnings
 
 import pytest
 import test_util

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -22,7 +22,9 @@ class ComparableX509Test(unittest.TestCase):
         self.cert_other = test_util.load_comparable_cert("cert-san.pem")
 
     def test_getattr_proxy(self) -> None:
-        assert self.cert1.has_expired() is True
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', message='datetime.datetime.utcnow() is deprecated')
+            assert self.cert1.has_expired() is True
 
     def test_eq(self) -> None:
         assert self.req1 == self.req2

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -24,7 +24,8 @@ class ComparableX509Test(unittest.TestCase):
 
     def test_getattr_proxy(self) -> None:
         with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', message='datetime.datetime.utcnow() is deprecated')
+            warnings.filterwarnings('ignore', category=DeprecationWarning,
+                message='.*Use timezone-aware objects to represent datetimes')
             assert self.cert1.has_expired() is True
 
     def test_eq(self) -> None:

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -24,8 +24,11 @@ class ComparableX509Test(unittest.TestCase):
 
     def test_getattr_proxy(self) -> None:
         with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', category=DeprecationWarning,
-                message='.*Use timezone-aware objects to represent datetimes')
+            warnings.filterwarnings(
+                "ignore",
+                category=DeprecationWarning,
+                message=".*Use timezone-aware objects to represent datetimes",
+            )
             assert self.cert1.has_expired() is True
 
     def test_eq(self) -> None:


### PR DESCRIPTION
Since we're likely to deprecate this whole function soon anyway, I am putting the warning filter directly in the code. This fixes the tests currently [failing](https://github.com/certbot/josepy/actions/runs/12604702846) on master.