### PR TITLE
Issue deprecation warnings when calling objects that use pyopenssl in their signatures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,8 @@ filterwarnings = [
     "ignore:CSR support in pyOpenSSL is deprecated:DeprecationWarning",
     # We ignore our own warning about dropping Python 3.8 support.
     "ignore:Python 3.8 support will be dropped:DeprecationWarning",
+    # We ignore our own warning about breaking changes in 2.0.
+    "ignore:The next major josepy release will deprecate:DeprecationWarning",
 ]
 norecursedirs = "*.egg .eggs dist build docs .tox"
 

--- a/src/josepy/json_util.py
+++ b/src/josepy/json_util.py
@@ -10,6 +10,7 @@ The framework presented here is somewhat based on `Go's "json" package`_
 import abc
 import binascii
 import logging
+import warnings
 from typing import (
     Any,
     Callable,
@@ -433,6 +434,12 @@ def encode_cert(cert: util.ComparableX509) -> str:
     :rtype: unicode
 
     """
+    warnings.warn(
+        "The next major josepy release will deprecate the use of PyOpenSSL in favor of "
+        "cryptography, including in method signatures. This will be a breaking change. To avoid "
+        "breakage, pin josepy < 2.0.0.",
+        DeprecationWarning,
+    )
     if isinstance(cert.wrapped, crypto.X509Req):
         raise ValueError("Error input is actually a certificate request.")
 
@@ -446,6 +453,12 @@ def decode_cert(b64der: str) -> util.ComparableX509:
     :rtype: `OpenSSL.crypto.X509` wrapped in `.ComparableX509`
 
     """
+    warnings.warn(
+        "The next major josepy release will deprecate the use of PyOpenSSL in favor of "
+        "cryptography, including in method signatures. This will be a breaking change. To avoid "
+        "breakage, pin josepy < 2.0.0.",
+        DeprecationWarning,
+    )
     try:
         return util.ComparableX509(
             crypto.load_certificate(crypto.FILETYPE_ASN1, decode_b64jose(b64der))
@@ -461,6 +474,12 @@ def encode_csr(csr: util.ComparableX509) -> str:
     :rtype: unicode
 
     """
+    warnings.warn(
+        "The next major josepy release will deprecate the use of PyOpenSSL in favor of "
+        "cryptography, including in method signatures. This will be a breaking change. To avoid "
+        "breakage, pin josepy < 2.0.0.",
+        DeprecationWarning,
+    )
     if isinstance(csr.wrapped, crypto.X509):
         raise ValueError("Error input is actually a certificate.")
 
@@ -474,6 +493,12 @@ def decode_csr(b64der: str) -> util.ComparableX509:
     :rtype: `OpenSSL.crypto.X509Req` wrapped in `.ComparableX509`
 
     """
+    warnings.warn(
+        "The next major josepy release will deprecate the use of PyOpenSSL in favor of "
+        "cryptography, including in method signatures. This will be a breaking change. To avoid "
+        "breakage, pin josepy < 2.0.0.",
+        DeprecationWarning,
+    )
     try:
         return util.ComparableX509(
             crypto.load_certificate_request(crypto.FILETYPE_ASN1, decode_b64jose(b64der))

--- a/src/josepy/jws.py
+++ b/src/josepy/jws.py
@@ -3,6 +3,7 @@
 import argparse
 import base64
 import sys
+import warnings
 from typing import (
     Any,
     Dict,
@@ -138,6 +139,12 @@ class Header(json_util.JSONObjectWithFields):
 
     @x5c.encoder  # type: ignore
     def x5c(value):
+        warnings.warn(
+            "The next major josepy release will deprecate the use of PyOpenSSL in favor of "
+            "cryptography, including in method signatures. This will be a breaking change. "
+            "To avoid breakage, pin josepy < 2.0.0.",
+            DeprecationWarning,
+        )
         return [
             base64.b64encode(crypto.dump_certificate(crypto.FILETYPE_ASN1, cert.wrapped))
             for cert in value
@@ -145,6 +152,12 @@ class Header(json_util.JSONObjectWithFields):
 
     @x5c.decoder  # type: ignore
     def x5c(value):
+        warnings.warn(
+            "The next major josepy release will deprecate the use of PyOpenSSL in favor of "
+            "cryptography, including in method signatures. This will be a breaking change. "
+            "To avoid breakage, pin josepy < 2.0.0.",
+            DeprecationWarning,
+        )
         try:
             return tuple(
                 util.ComparableX509(

--- a/src/josepy/util.py
+++ b/src/josepy/util.py
@@ -25,6 +25,12 @@ class ComparableX509:
     """
 
     def __init__(self, wrapped: Union[crypto.X509, crypto.X509Req]) -> None:
+        warnings.warn(
+            "The next major josepy release will deprecate the use of PyOpenSSL in favor of "
+            "cryptography, including in method signatures. This will be a breaking change. "
+            "To avoid breakage, pin josepy < 2.0.0.",
+            DeprecationWarning,
+        )
         assert isinstance(wrapped, crypto.X509) or isinstance(wrapped, crypto.X509Req)
         self.wrapped = wrapped
 


### PR DESCRIPTION
We're going to have to make breaking changes post-2.0 no matter what due to things like `x5c` in `jws`. Assuming we go down the route of using the style of changes in #182 and just making a clean break, here are deprecation warnings so that users are aware of the upcoming transition. I used the same message in each place since we don't actually have a finalized PR with the changes we will make. If we do want more specific messages, we should have a reviewed PR ready so that the messages about what the changes will be are accurate.

edit: https://github.com/certbot/josepy/pull/197/ is a more recent PR. it's similar to #182, though it doesn't remove `ComparableX509`. It may be easier to build off of.