### PR TITLE
deprecate comparablex509

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,14 @@ Changelog
 
 1.15.0 (main)
 ---------------
+
+* Added deprecation warnings about future backwards incompatible changes. The
+  text of that warning is "The next major version of josepy will remove
+  josepy.util.ComparableX509 and all uses of it as part of removing our
+  dependency on PyOpenSSL. This includes modifying any functions with
+  ComparableX509 parameters or return values. This will be a breaking change.
+  To avoid breakage, we recommend pinning josepy < 2.0.0 until josepy 2.0.0 is
+  out and you've had time to update your code."
 * Added support for Python 3.13.
 * Dropped support for Python 3.7.
 * Support for Python 3.8 has been deprecated and will be removed in the next

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,8 @@ filterwarnings = [
     "ignore:CSR support in pyOpenSSL is deprecated:DeprecationWarning",
     # We ignore our own warning about dropping Python 3.8 support.
     "ignore:Python 3.8 support will be dropped:DeprecationWarning",
+    # We ignore our own warning about ComparableX509
+    "ignore:.*josepy will remove josepy.util.ComparableX509",
 ]
 norecursedirs = "*.egg .eggs dist build docs .tox"
 

--- a/src/josepy/util.py
+++ b/src/josepy/util.py
@@ -25,6 +25,15 @@ class ComparableX509:
     """
 
     def __init__(self, wrapped: Union[crypto.X509, crypto.X509Req]) -> None:
+        warnings.warn(
+            "The next major version of josepy will remove josepy.util.ComparableX509 and all "
+            "uses of it as part of removing our dependency on PyOpenSSL. This includes "
+            "modifying any functions with ComparableX509 parameters or return values. This "
+            "will be a breaking change. To avoid breakage, we recommend pinning josepy < 2.0.0 "
+            "until josepy 2.0.0 is out and you've had time to update your code.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         assert isinstance(wrapped, crypto.X509) or isinstance(wrapped, crypto.X509Req)
         self.wrapped = wrapped
 


### PR DESCRIPTION
this is an alternate to https://github.com/certbot/josepy/pull/206

one thing i noticed is that all code deprecated in #206 uses ComparableX509 in some way so maybe we could just put this warning in one spot. i also expanded the warning text a bit and put something about it in the changelog

initially i also wanted to make use of code like https://github.com/certbot/josepy/blob/main/src/josepy/util.py#L259-L293 so users who have code like `from josepy.util import ComparableX509` get a warning about that problematic import as well, but it's kind of annoying because we also reexport ComparableX509 in `__init__.py`. we could also do the same thing there, but it gets a little messy because with a naive approach `__init__.py` would be generating its own warning for importing `josepy.util.ComparableX509` on top of generating another warning if anyone touches the reexported attribute. i personally think all that is probably too much to be worth the effort and this warning in `ComparableX509.__init__` is good enough

erica, feel free to suggest changes or update one of your own PRs with proposed alternatives