### PR TITLE
switch to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @certbot/eff-devs

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    reviewers:
-      - "certbot/eff-devs"
     groups:
       # one might want to only have dependabot open PRs for security updates,
       # but in practice, that doesn't seem to work well because for security


### PR DESCRIPTION
this is a response to https://github.com/certbot/josepy/pull/223#issuecomment-2892664678

we could limit codeowners to only match pinning changes to mimic how dependabot worked, but i personally think automatic assignment of any new PRs is pretty nice. maybe if this works well, we could even try it on the certbot repo?

i propose we try it here and see how we feel about it