### PR TITLE
add versioning-strategy: "widen" to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    versioning-strategy: "widen"
     groups:
       # one might want to only have dependabot open PRs for security updates,
       # but in practice, that doesn't seem to work well because for security


### PR DESCRIPTION
in https://github.com/certbot/josepy/pull/267, dependabot tried to change our minimum required package versions to the latest available version. i don't think we want that. why make our dependency versions stricter than they need to be?

to fix this i propose adding a [version strategy](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#versioning-strategy--) which is supposed to be dependabot's default behavior for software libraries like josepy

i don't think this PR requires two reviews