### PR TITLE
change strategy to lockfile-only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    versioning-strategy: "widen"
+    versioning-strategy: "lockfile-only"
     groups:
       # one might want to only have dependabot open PRs for security updates,
       # but in practice, that doesn't seem to work well because for security


### PR DESCRIPTION
this is a follow up to https://github.com/certbot/josepy/pull/268

one would think that based on the description of "widen", it'd have fixed the problems seen in https://github.com/certbot/josepy/pull/267 of bumping our dependency requirements to the latest version. unfortunately it seems that despite [widen being documented](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#versioning-strategy--), it [isn't supported for python](https://github.com/dependabot/dependabot-core/issues/6630). additionally, [many other people are also annoyed with dependabot's new behavior here](https://github.com/dependabot/dependabot-core/issues/14798)

this PR actually fixes the issue which you can see on my fork [here](https://github.com/bmw/josepy/pull/18). i'm sorry i didn't test it on my fork the first time, but i figured it'd just work and doing so wouldn't be needed. how silly of me 😩 

i don't think this PR requires two reviews